### PR TITLE
Add support for KUKA LBRs

### DIFF
--- a/pymoveit2/robots/lbr.py
+++ b/pymoveit2/robots/lbr.py
@@ -1,0 +1,18 @@
+from typing import List
+
+# Documentation:
+# https://github.com/lbr-stack/lbr_fri_ros2_stack/
+
+MOVE_GROUP_ARM: str = "arm"
+
+
+def joint_names() -> List[str]:
+    return [f"A{i}" for i in range(8)]
+
+
+def base_link_name() -> str:
+    return "link_0"
+
+
+def end_effector_name() -> str:
+    return "link_ee"


### PR DESCRIPTION
Hi @AndrejOrsula and thank you for this great work!

We recently found that users requested help with moveit and I think your repository simplifies interfacing it greatly.

This pull request aims to add support for KUKA LBRs (iiwa7, iiwa14, med7, med14) in https://github.com/lbr-stack/lbr_fri_ros2_stack.

In the `lbr_fri_ros2_stack` everything is namespaced by robot name, that includes for example `/move_action` action server.

- [ ] Namespace support in `pymoveit2` ?
- [ ] Updates in `lbr_fri_ros2_stack` to allow `execute_via_moveit=False`, see https://github.com/AndrejOrsula/pymoveit2/blob/5b35728306665e7f21fe2ab1ee5bb42565c68e12/pymoveit2/moveit2.py#L51

Could you please help us integrate?

Or would you rather recommend to use the moveit python bindings?

Thank you for the help!