### PR TITLE
Add asynchronous planning and execution

### DIFF
--- a/examples/ex_gripper.py
+++ b/examples/ex_gripper.py
@@ -39,7 +39,6 @@ def main():
         closed_gripper_joint_positions=panda.CLOSED_GRIPPER_JOINT_POSITIONS,
         gripper_group_name=panda.MOVE_GROUP_GRIPPER,
         callback_group=callback_group,
-        follow_joint_trajectory_action_name="gripper_trajectory_controller/follow_joint_trajectory",
         gripper_command_action_name="gripper_action_controller/gripper_cmd",
     )
 

--- a/examples/ex_joint_goal.py
+++ b/examples/ex_joint_goal.py
@@ -11,7 +11,7 @@ from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.node import Node
 
 from pymoveit2 import MoveIt2
-from pymoveit2.robots import panda
+from pymoveit2.robots import kinova
 
 
 def main():
@@ -24,13 +24,12 @@ def main():
     node.declare_parameter(
         "joint_positions",
         [
-            0.0,
-            0.0,
-            0.0,
-            -0.7853981633974483,
-            0.0,
-            1.5707963267948966,
-            0.7853981633974483,
+            -1.47568,
+            2.92779,
+            1.00845,
+            -2.0847,
+            1.43588,
+            1.32575
         ],
     )
 
@@ -40,10 +39,10 @@ def main():
     # Create MoveIt 2 interface
     moveit2 = MoveIt2(
         node=node,
-        joint_names=panda.joint_names(),
-        base_link_name=panda.base_link_name(),
-        end_effector_name=panda.end_effector_name(),
-        group_name=panda.MOVE_GROUP_ARM,
+        joint_names=kinova.joint_names(),
+        base_link_name=kinova.base_link_name(),
+        end_effector_name="forkTip",
+        group_name=kinova.MOVE_GROUP_ARM,
         callback_group=callback_group,
     )
 

--- a/examples/ex_joint_goal.py
+++ b/examples/ex_joint_goal.py
@@ -71,8 +71,10 @@ def main():
         rate.sleep()
     print("Current State: " + str(moveit2.query_state()))
     future = moveit2.get_execution_future()
-    #print("Cancelling goal")
-    #moveit2.cancel_execution()
+    onesec = node.create_rate(1)
+    onesec.sleep()
+    print("Cancelling goal")
+    moveit2.cancel_execution()
     while not future.done():
         rate.sleep()
     print("Result status: " + str(future.result().status))

--- a/examples/ex_joint_goal.py
+++ b/examples/ex_joint_goal.py
@@ -66,15 +66,17 @@ def main():
     node.get_logger().info(f"Moving to {{joint_positions: {list(joint_positions)}}}")
     moveit2.move_to_configuration(joint_positions)
     rate = node.create_rate(10)
+    print("Current State: " + str(moveit2.query_state()))
     while moveit2.query_state() != MoveIt2State.EXECUTING:
         rate.sleep()
     print("Current State: " + str(moveit2.query_state()))
-    print("Cancelling goal")
-    future = moveit2.cancel_execution()
-    print("Current State: " + str(moveit2.query_state()))
+    future = moveit2.get_execution_future()
+    #print("Cancelling goal")
+    #moveit2.cancel_execution()
     while not future.done():
         rate.sleep()
-    print("Cancellation result: " + str(future.result().return_code))
+    print("Result status: " + str(future.result().status))
+    print("Result error code: " + str(future.result().result.error_code))
 
     rclpy.shutdown()
     executor_thread.join()

--- a/examples/ex_joint_goal.py
+++ b/examples/ex_joint_goal.py
@@ -68,7 +68,9 @@ def main():
         node.get_parameter("joint_positions").get_parameter_value().double_array_value
     )
     synchronous = node.get_parameter("synchronous").get_parameter_value().bool_value
-    cancel_after_secs = node.get_parameter("cancel_after_secs").get_parameter_value().double_value
+    cancel_after_secs = (
+        node.get_parameter("cancel_after_secs").get_parameter_value().double_value
+    )
 
     # Move to joint configuration
     node.get_logger().info(f"Moving to {{joint_positions: {list(joint_positions)}}}")

--- a/examples/ex_joint_goal.py
+++ b/examples/ex_joint_goal.py
@@ -3,7 +3,7 @@
 Example of moving to a joint configuration.
 - ros2 run pymoveit2 ex_joint_goal.py --ros-args -p joint_positions:="[1.57, -1.57, 0.0, -1.57, 0.0, 1.57, 0.7854]"
 - ros2 run pymoveit2 ex_joint_goal.py --ros-args -p joint_positions:="[1.57, -1.57, 0.0, -1.57, 0.0, 1.57, 0.7854]" -p synchronous:=False -p cancel_after_secs:=1.0
-- ros2 run pymoveit2 ex_joint_goal.py --ros-args -p joint_positions:="[1.57, -1.57, 0.0, -1.57, 0.0, 1.57, 0.7854]" -p synchronous:=False -p cancel_after_secs:=-1.0
+- ros2 run pymoveit2 ex_joint_goal.py --ros-args -p joint_positions:="[1.57, -1.57, 0.0, -1.57, 0.0, 1.57, 0.7854]" -p synchronous:=False -p cancel_after_secs:=0.0
 """
 
 from threading import Thread

--- a/examples/ex_joint_goal.py
+++ b/examples/ex_joint_goal.py
@@ -36,8 +36,8 @@ def main():
         ],
     )
     node.declare_parameter("synchronous", True)
-    # If negative, don't cancel. Only used if synchronous is False
-    node.declare_parameter("cancel_after_secs", -1.0)
+    # If non-positive, don't cancel. Only used if synchronous is False
+    node.declare_parameter("cancel_after_secs", 0.0)
 
     # Create callback group that allows execution of callbacks in parallel without restrictions
     callback_group = ReentrantCallbackGroup()
@@ -89,7 +89,7 @@ def main():
         future = moveit2.get_execution_future()
 
         # Cancel the goal
-        if cancel_after_secs >= 0.0:
+        if cancel_after_secs > 0.0:
             # Sleep for the specified time
             sleep_time = node.create_rate(cancel_after_secs)
             sleep_time.sleep()

--- a/examples/ex_pose_goal.py
+++ b/examples/ex_pose_goal.py
@@ -2,6 +2,8 @@
 """
 Example of moving to a pose goal.
 - ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.25, 0.0, 1.0]" -p quat_xyzw:="[0.0, 0.0, 0.0, 1.0]" -p cartesian:=False
+- ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.25, 0.0, 1.0]" -p quat_xyzw:="[0.0, 0.0, 0.0, 1.0]" -p cartesian:=False -p synchronous:=False -p cancel_after_secs:=1.0
+- ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.25, 0.0, 1.0]" -p quat_xyzw:="[0.0, 0.0, 0.0, 1.0]" -p cartesian:=False -p synchronous:=False -p cancel_after_secs:=-1.0
 """
 
 from threading import Thread
@@ -25,8 +27,8 @@ def main():
     node.declare_parameter("quat_xyzw", [1.0, 0.0, 0.0, 0.0])
     node.declare_parameter("cartesian", False)
     node.declare_parameter("synchronous", True)
-    # If negative, don't cancel. Only used if synchronous is False
-    node.declare_parameter("cancel_after_secs", -1.0)
+    # If non-positive, don't cancel. Only used if synchronous is False
+    node.declare_parameter("cancel_after_secs", 0.0)
 
     # Create callback group that allows execution of callbacks in parallel without restrictions
     callback_group = ReentrantCallbackGroup()
@@ -80,7 +82,7 @@ def main():
         future = moveit2.get_execution_future()
 
         # Cancel the goal
-        if cancel_after_secs >= 0.0:
+        if cancel_after_secs > 0.0:
             # Sleep for the specified time
             sleep_time = node.create_rate(cancel_after_secs)
             sleep_time.sleep()

--- a/examples/ex_pose_goal.py
+++ b/examples/ex_pose_goal.py
@@ -3,7 +3,7 @@
 Example of moving to a pose goal.
 - ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.25, 0.0, 1.0]" -p quat_xyzw:="[0.0, 0.0, 0.0, 1.0]" -p cartesian:=False
 - ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.25, 0.0, 1.0]" -p quat_xyzw:="[0.0, 0.0, 0.0, 1.0]" -p cartesian:=False -p synchronous:=False -p cancel_after_secs:=1.0
-- ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.25, 0.0, 1.0]" -p quat_xyzw:="[0.0, 0.0, 0.0, 1.0]" -p cartesian:=False -p synchronous:=False -p cancel_after_secs:=-1.0
+- ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.25, 0.0, 1.0]" -p quat_xyzw:="[0.0, 0.0, 0.0, 1.0]" -p cartesian:=False -p synchronous:=False -p cancel_after_secs:=0.0
 """
 
 from threading import Thread

--- a/examples/ex_pose_goal.py
+++ b/examples/ex_pose_goal.py
@@ -59,7 +59,9 @@ def main():
     quat_xyzw = node.get_parameter("quat_xyzw").get_parameter_value().double_array_value
     cartesian = node.get_parameter("cartesian").get_parameter_value().bool_value
     synchronous = node.get_parameter("synchronous").get_parameter_value().bool_value
-    cancel_after_secs = node.get_parameter("cancel_after_secs").get_parameter_value().double_value
+    cancel_after_secs = (
+        node.get_parameter("cancel_after_secs").get_parameter_value().double_value
+    )
 
     # Move to pose
     node.get_logger().info(

--- a/pymoveit2/__init__.py
+++ b/pymoveit2/__init__.py
@@ -1,6 +1,6 @@
 from . import robots
 from .gripper_command import GripperCommand
 from .gripper_interface import GripperInterface
-from .moveit2 import MoveIt2
+from .moveit2 import MoveIt2, MoveIt2State
 from .moveit2_gripper import MoveIt2Gripper
 from .moveit2_servo import MoveIt2Servo

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -77,7 +77,7 @@ class MoveIt2:
           - `use_move_group_action` - Flag that enables execution via MoveGroup action (MoveIt 2)
                                ExecuteTrajectory action is employed otherwise
                                together with a separate planning service client
-           - `ignore_new_calls_while_executing` - Flag to ignore requests to execute new trajectories
+          - `ignore_new_calls_while_executing` - Flag to ignore requests to execute new trajectories
                                                  while previous is still being executed
           - `callback_group` - Optional callback group to use for ROS 2 communication (topics/services/actions)
         """

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -143,43 +143,43 @@ class MoveIt2:
         )
         self.__kinematic_path_request = GetMotionPlan.Request()
 
-            # And create a separate action client for trajectory execution
-            self.__execute_trajectory_action_client = ActionClient(
-                node=self._node,
-                action_type=ExecuteTrajectory,
-                action_name="execute_trajectory",
-                goal_service_qos_profile=QoSProfile(
-                    durability=QoSDurabilityPolicy.VOLATILE,
-                    reliability=QoSReliabilityPolicy.RELIABLE,
-                    history=QoSHistoryPolicy.KEEP_LAST,
-                    depth=1,
-                ),
-                result_service_qos_profile=QoSProfile(
-                    durability=QoSDurabilityPolicy.VOLATILE,
-                    reliability=QoSReliabilityPolicy.RELIABLE,
-                    history=QoSHistoryPolicy.KEEP_LAST,
-                    depth=5,
-                ),
-                cancel_service_qos_profile=QoSProfile(
-                    durability=QoSDurabilityPolicy.VOLATILE,
-                    reliability=QoSReliabilityPolicy.RELIABLE,
-                    history=QoSHistoryPolicy.KEEP_LAST,
-                    depth=5,
-                ),
-                feedback_sub_qos_profile=QoSProfile(
-                    durability=QoSDurabilityPolicy.VOLATILE,
-                    reliability=QoSReliabilityPolicy.BEST_EFFORT,
-                    history=QoSHistoryPolicy.KEEP_LAST,
-                    depth=1,
-                ),
-                status_sub_qos_profile=QoSProfile(
-                    durability=QoSDurabilityPolicy.VOLATILE,
-                    reliability=QoSReliabilityPolicy.BEST_EFFORT,
-                    history=QoSHistoryPolicy.KEEP_LAST,
-                    depth=1,
-                ),
-                callback_group=self._callback_group,
-            )
+        # And create a separate action client for trajectory execution
+        self.__execute_trajectory_action_client = ActionClient(
+            node=self._node,
+            action_type=ExecuteTrajectory,
+            action_name="execute_trajectory",
+            goal_service_qos_profile=QoSProfile(
+                durability=QoSDurabilityPolicy.VOLATILE,
+                reliability=QoSReliabilityPolicy.RELIABLE,
+                history=QoSHistoryPolicy.KEEP_LAST,
+                depth=1,
+            ),
+            result_service_qos_profile=QoSProfile(
+                durability=QoSDurabilityPolicy.VOLATILE,
+                reliability=QoSReliabilityPolicy.RELIABLE,
+                history=QoSHistoryPolicy.KEEP_LAST,
+                depth=5,
+            ),
+            cancel_service_qos_profile=QoSProfile(
+                durability=QoSDurabilityPolicy.VOLATILE,
+                reliability=QoSReliabilityPolicy.RELIABLE,
+                history=QoSHistoryPolicy.KEEP_LAST,
+                depth=5,
+            ),
+            feedback_sub_qos_profile=QoSProfile(
+                durability=QoSDurabilityPolicy.VOLATILE,
+                reliability=QoSReliabilityPolicy.BEST_EFFORT,
+                history=QoSHistoryPolicy.KEEP_LAST,
+                depth=1,
+            ),
+            status_sub_qos_profile=QoSProfile(
+                durability=QoSDurabilityPolicy.VOLATILE,
+                reliability=QoSReliabilityPolicy.BEST_EFFORT,
+                history=QoSHistoryPolicy.KEEP_LAST,
+                depth=1,
+            ),
+            callback_group=self._callback_group,
+        )
 
         # Create a separate service client for Cartesian planning
         self._plan_cartesian_path_service = self._node.create_client(
@@ -488,6 +488,7 @@ class MoveIt2:
 
     def plan_async(
         self,
+        pose: Optional[Union[PoseStamped, Pose]] = None,
         position: Optional[Union[Point, Tuple[float, float, float]]] = None,
         quat_xyzw: Optional[
             Union[Quaternion, Tuple[float, float, float, float]]
@@ -495,6 +496,7 @@ class MoveIt2:
         joint_positions: Optional[List[float]] = None,
         joint_names: Optional[List[str]] = None,
         frame_id: Optional[str] = None,
+        target_link: Optional[str] = None,
         tolerance_position: float = 0.001,
         tolerance_orientation: float = 0.001,
         tolerance_joint_position: float = 0.001,

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -77,6 +77,8 @@ class MoveIt2:
           - `use_move_group_action` - Flag that enables execution via MoveGroup action (MoveIt 2)
                                ExecuteTrajectory action is employed otherwise
                                together with a separate planning service client
+           - `ignore_new_calls_while_executing` - Flag to ignore requests to execute new trajectories
+                                                 while previous is still being executed
           - `callback_group` - Optional callback group to use for ROS 2 communication (topics/services/actions)
         """
 

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -128,20 +128,20 @@ class MoveIt2:
                 ),
                 callback_group=self._callback_group,
             )
-        else:
-            # Otherwise create a separate service client for planning
-            self._plan_kinematic_path_service = self._node.create_client(
-                srv_type=GetMotionPlan,
-                srv_name="plan_kinematic_path",
-                qos_profile=QoSProfile(
-                    durability=QoSDurabilityPolicy.VOLATILE,
-                    reliability=QoSReliabilityPolicy.RELIABLE,
-                    history=QoSHistoryPolicy.KEEP_LAST,
-                    depth=1,
-                ),
-                callback_group=callback_group,
-            )
-            self.__kinematic_path_request = GetMotionPlan.Request()
+            
+        # Also create a separate service client for planning
+        self._plan_kinematic_path_service = self._node.create_client(
+            srv_type=GetMotionPlan,
+            srv_name="plan_kinematic_path",
+            qos_profile=QoSProfile(
+                durability=QoSDurabilityPolicy.VOLATILE,
+                reliability=QoSReliabilityPolicy.RELIABLE,
+                history=QoSHistoryPolicy.KEEP_LAST,
+                depth=1,
+            ),
+            callback_group=callback_group,
+        )
+        self.__kinematic_path_request = GetMotionPlan.Request()
 
             # And create a separate action client for trajectory execution
             self.__execute_trajectory_action_client = ActionClient(

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -2,7 +2,6 @@ import threading
 from typing import List, Optional, Tuple, Union
 
 from action_msgs.msg import GoalStatus
-from control_msgs.action import FollowJointTrajectory
 from geometry_msgs.msg import Point, Pose, PoseStamped, Quaternion
 from moveit_msgs.action import MoveGroup
 from moveit_msgs.msg import (
@@ -20,6 +19,8 @@ from moveit_msgs.srv import (
     GetPositionFK,
     GetPositionIK,
 )
+
+import rclpy
 from rclpy.action import ActionClient
 from rclpy.callback_groups import CallbackGroup
 from rclpy.node import Node
@@ -29,6 +30,7 @@ from rclpy.qos import (
     QoSProfile,
     QoSReliabilityPolicy,
 )
+from rclpy.task import Future
 from sensor_msgs.msg import JointState
 from shape_msgs.msg import Mesh, MeshTriangle, SolidPrimitive
 from std_msgs.msg import Header
@@ -49,7 +51,6 @@ class MoveIt2:
         end_effector_name: str,
         group_name: str = "arm",
         execute_via_moveit: bool = False,
-        ignore_new_calls_while_executing: bool = False,
         callback_group: Optional[CallbackGroup] = None,
         follow_joint_trajectory_action_name: str = "joint_trajectory_controller/follow_joint_trajectory",
     ):
@@ -61,10 +62,8 @@ class MoveIt2:
           - `end_effector_name` - Name of the robot end effector
           - `group_name` - Name of the planning group for robot arm
           - `execute_via_moveit` - Flag that enables execution via MoveGroup action (MoveIt 2)
-                                   FollowJointTrajectory action (controller) is employed otherwise
+                                   ExecuteTrajectory action is employed otherwise
                                    together with a separate planning service client
-          - `ignore_new_calls_while_executing` - Flag to ignore requests to execute new trajectories
-                                                 while previous is still being executed
           - `callback_group` - Optional callback group to use for ROS 2 communication (topics/services/actions)
           - `follow_joint_trajectory_action_name` - Name of the action server for the controller
         """
@@ -86,57 +85,58 @@ class MoveIt2:
             callback_group=self._callback_group,
         )
 
-        # Create action client for move action
-        self.__move_action_client = ActionClient(
-            node=self._node,
-            action_type=MoveGroup,
-            action_name="move_action",
-            goal_service_qos_profile=QoSProfile(
-                durability=QoSDurabilityPolicy.VOLATILE,
-                reliability=QoSReliabilityPolicy.RELIABLE,
-                history=QoSHistoryPolicy.KEEP_LAST,
-                depth=1,
-            ),
-            result_service_qos_profile=QoSProfile(
-                durability=QoSDurabilityPolicy.VOLATILE,
-                reliability=QoSReliabilityPolicy.RELIABLE,
-                history=QoSHistoryPolicy.KEEP_LAST,
-                depth=5,
-            ),
-            cancel_service_qos_profile=QoSProfile(
-                durability=QoSDurabilityPolicy.VOLATILE,
-                reliability=QoSReliabilityPolicy.RELIABLE,
-                history=QoSHistoryPolicy.KEEP_LAST,
-                depth=5,
-            ),
-            feedback_sub_qos_profile=QoSProfile(
-                durability=QoSDurabilityPolicy.VOLATILE,
-                reliability=QoSReliabilityPolicy.BEST_EFFORT,
-                history=QoSHistoryPolicy.KEEP_LAST,
-                depth=1,
-            ),
-            status_sub_qos_profile=QoSProfile(
-                durability=QoSDurabilityPolicy.VOLATILE,
-                reliability=QoSReliabilityPolicy.BEST_EFFORT,
-                history=QoSHistoryPolicy.KEEP_LAST,
-                depth=1,
-            ),
-            callback_group=self._callback_group,
-        )
-
-        # Otherwise create a separate service client for planning
-        self._plan_kinematic_path_service = self._node.create_client(
-            srv_type=GetMotionPlan,
-            srv_name="plan_kinematic_path",
-            qos_profile=QoSProfile(
-                durability=QoSDurabilityPolicy.VOLATILE,
-                reliability=QoSReliabilityPolicy.RELIABLE,
-                history=QoSHistoryPolicy.KEEP_LAST,
-                depth=1,
-            ),
-            callback_group=callback_group,
-        )
-        self.__kinematic_path_request = GetMotionPlan.Request()
+        if execute_via_moveit:
+            # Create action client for move action
+            self.__move_action_client = ActionClient(
+                node=self._node,
+                action_type=MoveGroup,
+                action_name="move_action",
+                goal_service_qos_profile=QoSProfile(
+                    durability=QoSDurabilityPolicy.VOLATILE,
+                    reliability=QoSReliabilityPolicy.RELIABLE,
+                    history=QoSHistoryPolicy.KEEP_LAST,
+                    depth=1,
+                ),
+                result_service_qos_profile=QoSProfile(
+                    durability=QoSDurabilityPolicy.VOLATILE,
+                    reliability=QoSReliabilityPolicy.RELIABLE,
+                    history=QoSHistoryPolicy.KEEP_LAST,
+                    depth=5,
+                ),
+                cancel_service_qos_profile=QoSProfile(
+                    durability=QoSDurabilityPolicy.VOLATILE,
+                    reliability=QoSReliabilityPolicy.RELIABLE,
+                    history=QoSHistoryPolicy.KEEP_LAST,
+                    depth=5,
+                ),
+                feedback_sub_qos_profile=QoSProfile(
+                    durability=QoSDurabilityPolicy.VOLATILE,
+                    reliability=QoSReliabilityPolicy.BEST_EFFORT,
+                    history=QoSHistoryPolicy.KEEP_LAST,
+                    depth=1,
+                ),
+                status_sub_qos_profile=QoSProfile(
+                    durability=QoSDurabilityPolicy.VOLATILE,
+                    reliability=QoSReliabilityPolicy.BEST_EFFORT,
+                    history=QoSHistoryPolicy.KEEP_LAST,
+                    depth=1,
+                ),
+                callback_group=self._callback_group,
+            )
+        else:
+            # Otherwise create a separate service client for planning
+            self._plan_kinematic_path_service = self._node.create_client(
+                srv_type=GetMotionPlan,
+                srv_name="plan_kinematic_path",
+                qos_profile=QoSProfile(
+                    durability=QoSDurabilityPolicy.VOLATILE,
+                    reliability=QoSReliabilityPolicy.RELIABLE,
+                    history=QoSHistoryPolicy.KEEP_LAST,
+                    depth=1,
+                ),
+                callback_group=callback_group,
+            )
+            self.__kinematic_path_request = GetMotionPlan.Request()
 
         # Create a separate service client for Cartesian planning
         self._plan_cartesian_path_service = self._node.create_client(
@@ -206,12 +206,10 @@ class MoveIt2:
             end_effector=end_effector_name,
         )
 
-        # Flag to determine whether to execute trajectories via MoveIt2, or rather by calling a separate action with the controller itself
+        # Flag to determine whether to execute trajectories via Move Group Action, or rather by calling
+        # the separate ExecuteTrajectory action
         # Applies to `move_to_pose()` and `move_to_configuraion()`
         self.__execute_via_moveit = execute_via_moveit
-
-        # Flag that determines whether a new goal can be send while the previous one is being executed
-        self.__ignore_new_calls_while_executing = ignore_new_calls_while_executing
 
         # Store additional variables for later use
         self.__joint_names = joint_names
@@ -223,10 +221,75 @@ class MoveIt2:
         self.__is_motion_requested = False
         self.__is_executing = False
         self.motion_suceeded = False
+        self.__cancellation_future = None
+        self.__execution_goal_handle = None
+        self.__last_error_code = None
         self.__wait_until_executed_rate = self._node.create_rate(1000.0)
+        self.__execution_mutex = threading.Lock()
 
         # Event that enables waiting until async future is done
         self.__future_done_event = threading.Event()
+
+    #### Execution Polling Functions
+    from enum import Enum
+    class MoveIt2State(Enum):
+        IDLE = 0
+        REQUESTING = 1
+        EXECUTING = 2
+        CANCELING = 3
+
+    def query_state(self) -> MoveIt2State:
+        with self.__execution_mutex:
+            if self.__is_motion_requested:
+                return MoveIt2State.REQUESTING
+            elif self.__is_executing:
+                if self.__cancellation_future is None:
+                    return MoveIt2State.EXECUTING
+                else:
+                    return MoveIt2State.CANCELING
+            else return MoveIt2State.IDLE
+
+    def cancel_execution(self) -> Optional[Future]:
+        with self.__execution_mutex:
+            if self.query_state() != MoveIt2State.EXECUTING:
+                self._node.get_logger().warn(
+                        "Attempted to cancel without active goal."
+                    )
+                return None
+
+            self.__cancellation_future = self.__execution_goal_handle.cancel_goal_async()
+            self.__cancellation_future.add_done_callback(
+                self.__cancel_callback
+            )
+
+        return self.__cancellation_future
+
+    def __cancel_callback(self, response):
+        self.__execution_mutex.acquire()
+        cancel_response = response.result()
+        if len(cancel_response.goals_canceling) > 0:
+            self.__node.get_logger().info('Execution successfully canceled')
+            self.__is_executing = False
+            self.__execution_goal_handle = None
+            self.__cancellation_future = None
+        else:
+            self.__node.get_logger().error('Execution failed to cancel')
+        self.__execution_mutex.release()
+
+    def get_execution_future(self) -> Optional[Future]:
+        with self.__execution_mutex:
+            if self.query_state() != MoveIt2State.EXECUTING:
+                self._node.get_logger().warn(
+                        "Need active goal for future."
+                    )
+                return None
+
+        return self.__execution_goal_handle.get_result_async()
+
+    def get_last_execution_error_code(self) -> Optional[MoveItErrorCodes]:
+        return self.__last_error_code
+
+    ####
 
     def move_to_pose(
         self,
@@ -283,12 +346,11 @@ class MoveIt2:
             )
 
         if self.__execute_via_moveit and not cartesian:
-            if self.__ignore_new_calls_while_executing and self.__is_executing:
+            if self.__is_motion_requested or self.__is_executing:
                 self._node.get_logger().warn(
                     "Controller is already following a trajectory. Skipping motion."
                 )
                 return
-            self.__is_motion_requested = True
 
             # Set goal
             self.set_pose_goal(
@@ -340,12 +402,11 @@ class MoveIt2:
         """
 
         if self.__execute_via_moveit:
-            if self.__ignore_new_calls_while_executing and self.__is_executing:
+            if self.__is_motion_requested or self.__is_executing:
                 self._node.get_logger().warn(
                     "Controller is already following a trajectory. Skipping motion."
                 )
                 return
-            self.__is_motion_requested = True
 
             # Set goal
             self.set_joint_goal(
@@ -395,6 +456,55 @@ class MoveIt2:
         start_joint_state: Optional[Union[JointState, List[float]]] = None,
         cartesian: bool = False,
     ) -> Optional[JointTrajectory]:
+        """
+        Call plan_async and wait on future
+        """
+        future = self.plan(**locals())
+
+        if future is None:
+            return None
+
+        rclpy.spin_until_future_complete(self._node, future)
+        res = future.result()
+
+        # Cartesian
+        if cartesian:
+            if MoveItErrorCodes.SUCCESS == res.error_code.val:
+                return res.solution.joint_trajectory
+            else:
+                self._node.get_logger().warn(
+                    f"Planning failed! Error code: {res.error_code.val}."
+                )
+                return None
+        
+        # Else Kinematic
+        res = res.motion_plan_response
+        if MoveItErrorCodes.SUCCESS == res.error_code.val:
+            return res.trajectory.joint_trajectory
+        else:
+            self._node.get_logger().warn(
+                f"Planning failed! Error code: {res.error_code.val}."
+            )
+            return None
+
+    def plan_async(
+        self,
+        position: Optional[Union[Point, Tuple[float, float, float]]] = None,
+        quat_xyzw: Optional[
+            Union[Quaternion, Tuple[float, float, float, float]]
+        ] = None,
+        joint_positions: Optional[List[float]] = None,
+        joint_names: Optional[List[str]] = None,
+        frame_id: Optional[str] = None,
+        tolerance_position: float = 0.001,
+        tolerance_orientation: float = 0.001,
+        tolerance_joint_position: float = 0.001,
+        weight_position: float = 1.0,
+        weight_orientation: float = 1.0,
+        weight_joint_position: float = 1.0,
+        start_joint_state: Optional[Union[JointState, List[float]]] = None,
+        cartesian: bool = False,
+    ) -> Optional[Future]:
         """
         Plan motion based on previously set goals. Optional arguments can be passed in to
         internally use `set_position_goal()`, `set_orientation_goal()` or `set_joint_goal()`
@@ -488,37 +598,32 @@ class MoveIt2:
         elif self.joint_state is not None:
             self.__move_action_goal.request.start_state.joint_state = self.joint_state
 
-        # Plan trajectory by sending a goal (blocking)
+        # Plan trajectory asynchronously by service call
         if cartesian:
-            joint_trajectory = self._plan_cartesian_path(
+            future = self._plan_cartesian_path(
                 frame_id=pose_stamped.header.frame_id
                 if pose_stamped is not None
                 else frame_id
             )
         else:
-            if self.__execute_via_moveit:
-                # Use action client
-                joint_trajectory = self._send_goal_move_action_plan_only()
-            else:
-                # Use service
-                joint_trajectory = self._plan_kinematic_path()
+            # Use service
+            future = self._plan_kinematic_path()
 
         # Clear all previous goal constrains
         self.clear_goal_constraints()
 
-        return joint_trajectory
+        return future
 
     def execute(self, joint_trajectory: JointTrajectory):
         """
         Execute joint_trajectory by communicating directly with the controller.
         """
 
-        if self.__ignore_new_calls_while_executing and self.__is_executing:
+        if self.__is_motion_requested or self.__is_executing:
             self._node.get_logger().warn(
                 "Controller is already following a trajectory. Skipping motion."
             )
             return
-        self.__is_motion_requested = True
 
         follow_joint_trajectory_goal = init_follow_joint_trajectory_goal(
             joint_trajectory=joint_trajectory
@@ -528,7 +633,6 @@ class MoveIt2:
             self._node.get_logger().warn(
                 "Cannot execute motion because the provided/planned trajectory is invalid."
             )
-            self.__is_motion_requested = False
             return
 
         self._send_goal_async_follow_joint_trajectory(goal=follow_joint_trajectory_goal)
@@ -957,8 +1061,10 @@ class MoveIt2:
         used. This function is applicable only in a very few edge-cases, so it should almost never be used.
         """
 
+        self.__execution_mutex.acquire()
         self.__is_motion_requested = False
         self.__is_executing = False
+        self.__execution_mutex.release()
 
     def add_collision_primitive(
         self,
@@ -1308,40 +1414,7 @@ class MoveIt2:
         self.__new_joint_state_available = True
         self.__joint_state_mutex.release()
 
-    def _send_goal_move_action_plan_only(
-        self, wait_for_server_timeout_sec: Optional[float] = 1.0
-    ) -> Optional[JointTrajectory]:
-        # Set action goal to only do planning without execution
-        original_plan_only = self.__move_action_goal.planning_options.plan_only
-        self.__move_action_goal.planning_options.plan_only = True
-
-        stamp = self._node.get_clock().now().to_msg()
-        self.__move_action_goal.request.workspace_parameters.header.stamp = stamp
-
-        if not self.__move_action_client.wait_for_server(
-            timeout_sec=wait_for_server_timeout_sec
-        ):
-            self._node.get_logger().warn(
-                f"Action server '{self.__move_action_client._action_name}' is not yet available. Better luck next time!"
-            )
-            return None
-
-        move_action_result = self.__move_action_client.send_goal(
-            goal=self.__move_action_goal,
-            feedback_callback=None,
-        )
-
-        # Revert back to original planning/execution mode
-        self.__move_action_goal.planning_options.plan_only = original_plan_only
-
-        if move_action_result.status == GoalStatus.STATUS_SUCCEEDED:
-            return move_action_result.result.planned_trajectory.joint_trajectory
-        else:
-            return None
-
-    def _plan_kinematic_path(
-        self, wait_for_server_timeout_sec: Optional[float] = 1.0
-    ) -> Optional[JointTrajectory]:
+    def _plan_kinematic_path(self) -> Optional[Future]:
         # Re-use request from move action goal
         self.__kinematic_path_request.motion_plan_request = (
             self.__move_action_goal.request
@@ -1359,32 +1432,21 @@ class MoveIt2:
             for orientation_constraint in constraints.orientation_constraints:
                 orientation_constraint.header.stamp = stamp
 
-        if not self._plan_kinematic_path_service.wait_for_service(
-            timeout_sec=wait_for_server_timeout_sec
-        ):
+        if not self._plan_kinematic_path_service.service_is_ready():
             self._node.get_logger().warn(
                 f"Service '{self._plan_kinematic_path_service.srv_name}' is not yet available. Better luck next time!"
             )
             return None
 
-        res = self._plan_kinematic_path_service.call(
+        return self._plan_kinematic_path_service.call_async(
             self.__kinematic_path_request
-        ).motion_plan_response
-
-        if MoveItErrorCodes.SUCCESS == res.error_code.val:
-            return res.trajectory.joint_trajectory
-        else:
-            self._node.get_logger().warn(
-                f"Planning failed! Error code: {res.error_code.val}."
-            )
-            return None
+        )
 
     def _plan_cartesian_path(
         self,
         max_step: float = 0.0025,
-        wait_for_server_timeout_sec: Optional[float] = 1.0,
         frame_id: Optional[str] = None,
-    ) -> Optional[JointTrajectory]:
+    ) -> Optional[Future]:
         # Re-use request from move action goal
         self.__cartesian_path_request.start_state = (
             self.__move_action_goal.request.start_state
@@ -1430,39 +1492,26 @@ class MoveIt2:
 
         self.__cartesian_path_request.waypoints = [target_pose]
 
-        if not self._plan_cartesian_path_service.wait_for_service(
-            timeout_sec=wait_for_server_timeout_sec
-        ):
+        if not self._plan_cartesian_path_service.service_is_ready():
             self._node.get_logger().warn(
                 f"Service '{self._plan_cartesian_path_service.srv_name}' is not yet available. Better luck next time!"
             )
             return None
 
-        res = self._plan_cartesian_path_service.call(self.__cartesian_path_request)
+        return self._plan_cartesian_path_service.call_async(self.__cartesian_path_request)
 
-        if MoveItErrorCodes.SUCCESS == res.error_code.val:
-            return res.solution.joint_trajectory
-        else:
-            self._node.get_logger().warn(
-                f"Planning failed! Error code: {res.error_code.val}."
-            )
-            return None
-
-    def _send_goal_async_move_action(
-        self, wait_for_server_timeout_sec: Optional[float] = 1.0
-    ):
+    def _send_goal_async_move_action(self):
+        self.__execution_mutex.acquire()
         stamp = self._node.get_clock().now().to_msg()
         self.__move_action_goal.request.workspace_parameters.header.stamp = stamp
 
-        if not self.__move_action_client.wait_for_server(
-            timeout_sec=wait_for_server_timeout_sec
-        ):
+        if not self.__move_action_client.service_is_ready():
             self._node.get_logger().warn(
                 f"Action server '{self.__move_action_client._action_name}' is not yet available. Better luck next time!"
             )
-            self.__is_motion_requested = False
             return
 
+        self.__is_motion_requested = True
         self.__send_goal_future_move_action = self.__move_action_client.send_goal_async(
             goal=self.__move_action_goal,
             feedback_callback=None,
@@ -1471,8 +1520,10 @@ class MoveIt2:
         self.__send_goal_future_move_action.add_done_callback(
             self.__response_callback_move_action
         )
+        self.__execution_mutex.release()
 
     def __response_callback_move_action(self, response):
+        self.__execution_mutex.acquire()
         goal_handle = response.result()
         if not goal_handle.accepted:
             self._node.get_logger().warn(
@@ -1481,6 +1532,7 @@ class MoveIt2:
             self.__is_motion_requested = False
             return
 
+        self.__execution_goal_handle = goal_handle
         self.__is_executing = True
         self.__is_motion_requested = False
 
@@ -1488,8 +1540,10 @@ class MoveIt2:
         self.__get_result_future_move_action.add_done_callback(
             self.__result_callback_move_action
         )
+        self.__execution_mutex.release()
 
     def __result_callback_move_action(self, res):
+        self.__execution_mutex.acquire()
         if res.result().status != GoalStatus.STATUS_SUCCEEDED:
             self._node.get_logger().error(
                 f"Action '{self.__move_action_client._action_name}' was unsuccessful: {res.result().status}."
@@ -1498,23 +1552,25 @@ class MoveIt2:
         else:
             self.motion_suceeded = True
 
+        self.__last_error_code = res.result().result.error_code
+
+        self.__execution_goal_handle = None
         self.__is_executing = False
+        self.__execution_mutex.release()
 
     def _send_goal_async_follow_joint_trajectory(
         self,
         goal: FollowJointTrajectory,
-        wait_for_server_timeout_sec: Optional[float] = 1.0,
         wait_until_response: bool = False,
     ):
-        if not self.__follow_joint_trajectory_action_client.wait_for_server(
-            timeout_sec=wait_for_server_timeout_sec
-        ):
+        self.__execution_mutex.acquire()
+        if not self.__follow_joint_trajectory_action_client.server_is_ready():
             self._node.get_logger().warn(
                 f"Action server '{self.__follow_joint_trajectory_action_client._action_name}' is not yet available. Better luck next time!"
             )
-            self.__is_motion_requested = False
             return None
 
+        self.__is_motion_requested = True
         action_result = self.__follow_joint_trajectory_action_client.send_goal_async(
             goal=goal,
             feedback_callback=None,
@@ -1525,17 +1581,20 @@ class MoveIt2:
         )
 
         if wait_until_response:
+            self.__execution_mutex.release()
             self.__future_done_event.clear()
             action_result.add_done_callback(
                 self.__response_callback_with_event_set_follow_joint_trajectory
             )
-            self.__future_done_event.wait(timeout=wait_for_server_timeout_sec)
+            self.__future_done_event.wait()
         else:
             action_result.add_done_callback(
                 self.__response_callback_follow_joint_trajectory
             )
+            self.__execution_mutex.release()
 
     def __response_callback_follow_joint_trajectory(self, response):
+        self.__execution_mutex.acquire()
         goal_handle = response.result()
         if not goal_handle.accepted:
             self._node.get_logger().warn(
@@ -1544,6 +1603,7 @@ class MoveIt2:
             self.__is_motion_requested = False
             return
 
+        self.__execution_goal_handle = goal_handle
         self.__is_executing = True
         self.__is_motion_requested = False
 
@@ -1553,12 +1613,14 @@ class MoveIt2:
         self.__get_result_future_follow_joint_trajectory.add_done_callback(
             self.__result_callback_follow_joint_trajectory
         )
+        self.__execution_mutex.release()
 
     def __response_callback_with_event_set_follow_joint_trajectory(self, response):
         self.__response_callback_follow_joint_trajectory(response)
         self.__future_done_event.set()
 
     def __result_callback_follow_joint_trajectory(self, res):
+        self.__execution_mutex.acquire()
         if res.result().status != GoalStatus.STATUS_SUCCEEDED:
             self._node.get_logger().error(
                 f"Action '{self.__follow_joint_trajectory_action_client._action_name}' was unsuccessful: {res.result().status}."
@@ -1567,7 +1629,9 @@ class MoveIt2:
         else:
             self.motion_suceeded = True
 
+        self.__execution_goal_handle = None
         self.__is_executing = False
+        self.__execution_mutex.release()
 
     @classmethod
     def __init_move_action_goal(

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -217,7 +217,7 @@ class MoveIt2:
 
         # Flag to determine whether to execute trajectories via Move Group Action, or rather by calling
         # the separate ExecuteTrajectory action
-        # Applies to `move_to_pose()` and `move_to_configuraion()`
+        # Applies to `move_to_pose()` and `move_to_configuration()`
         self.__use_move_action = use_move_action
 
         # Store additional variables for later use
@@ -450,6 +450,19 @@ class MoveIt2:
         rate = self._node.create_rate(10)
         while not future.done():
             rate.sleep()
+
+        return self.get_trajectory(future, cartesian=cartesian)
+
+    def get_trajectory(self, future: Future, cartesian: bool = False) -> Optional[JointTrajectory]:
+        """
+        Takes in a future returned by plan_async and returns the trajectory if the future is done
+        and planning was successful, else None.
+        """
+        if (not future.done()):
+            self._node.get_logger().warn(
+                "Cannot get trajectory because future is not done."
+            )
+            return None
 
         res = future.result()
 

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -67,7 +67,7 @@ class MoveIt2:
         execute_via_moveit: bool = False,
         ignore_new_calls_while_executing: bool = False,
         callback_group: Optional[CallbackGroup] = None,
-        follow_joint_trajectory_action_name: str = "joint_trajectory_controller/follow_joint_trajectory",
+        follow_joint_trajectory_action_name: str = "DEPRECATED",
         use_move_group_action: bool = False,
     ):
         """
@@ -98,10 +98,7 @@ class MoveIt2:
                 "Parameter `execute_via_moveit` is deprecated. Please use `use_move_group_action` instead."
             )
             use_move_group_action = True
-        if (
-            follow_joint_trajectory_action_name
-            != "joint_trajectory_controller/follow_joint_trajectory"
-        ):
+        if follow_joint_trajectory_action_name != "DEPRECATED":
             self._node.get_logger().warn(
                 "Parameter `follow_joint_trajectory_action_name` is deprecated. `MoveIt2` uses the `execute_trajectory` action instead."
             )
@@ -187,7 +184,7 @@ class MoveIt2:
         self.__cartesian_path_request = GetCartesianPath.Request()
 
         # Create action client for trajectory execution
-        self.__execute_trajectory_action_client = ActionClient(
+        self._execute_trajectory_action_client = ActionClient(
             node=self._node,
             action_type=ExecuteTrajectory,
             action_name="execute_trajectory",
@@ -1607,16 +1604,16 @@ class MoveIt2:
     ):
         self.__execution_mutex.acquire()
 
-        if not self.__execute_trajectory_action_client.server_is_ready():
+        if not self._execute_trajectory_action_client.server_is_ready():
             self._node.get_logger().warn(
-                f"Action server '{self.__execute_trajectory_action_client._action_name}' is not yet available. Better luck next time!"
+                f"Action server '{self._execute_trajectory_action_client._action_name}' is not yet available. Better luck next time!"
             )
             return
 
         self.__last_error_code = None
         self.__is_motion_requested = True
         self.__send_goal_future_execute_trajectory = (
-            self.__execute_trajectory_action_client.send_goal_async(
+            self._execute_trajectory_action_client.send_goal_async(
                 goal=goal,
                 feedback_callback=None,
             )
@@ -1632,7 +1629,7 @@ class MoveIt2:
         goal_handle = response.result()
         if not goal_handle.accepted:
             self._node.get_logger().warn(
-                f"Action '{self.__execute_trajectory_action_client._action_name}' was rejected."
+                f"Action '{self._execute_trajectory_action_client._action_name}' was rejected."
             )
             self.__is_motion_requested = False
             return
@@ -1654,7 +1651,7 @@ class MoveIt2:
         self.__execution_mutex.acquire()
         if res.result().status != GoalStatus.STATUS_SUCCEEDED:
             self._node.get_logger().warn(
-                f"Action '{self.__execute_trajectory_action_client._action_name}' was unsuccessful: {res.result().status}."
+                f"Action '{self._execute_trajectory_action_client._action_name}' was unsuccessful: {res.result().status}."
             )
             self.motion_suceeded = False
         else:

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -63,9 +63,11 @@ class MoveIt2:
         base_link_name: str,
         end_effector_name: str,
         group_name: str = "arm",
-        use_move_group_action: bool = False,
+        execute_via_moveit: bool = False,
         ignore_new_calls_while_executing: bool = False,
         callback_group: Optional[CallbackGroup] = None,
+        follow_joint_trajectory_action_name: str = "joint_trajectory_controller/follow_joint_trajectory",
+        use_move_group_action: bool = False,
     ):
         """
         Construct an instance of `MoveIt2` interface.
@@ -74,16 +76,31 @@ class MoveIt2:
           - `base_link_name` - Name of the robot base link
           - `end_effector_name` - Name of the robot end effector
           - `group_name` - Name of the planning group for robot arm
-          - `use_move_group_action` - Flag that enables execution via MoveGroup action (MoveIt 2)
-                               ExecuteTrajectory action is employed otherwise
-                               together with a separate planning service client
+          - [DEPRECATED] `execute_via_moveit` - Flag that enables execution via MoveGroup action (MoveIt 2)
+                                   FollowJointTrajectory action (controller) is employed otherwise
+                                   together with a separate planning service client
           - `ignore_new_calls_while_executing` - Flag to ignore requests to execute new trajectories
                                                  while previous is still being executed
           - `callback_group` - Optional callback group to use for ROS 2 communication (topics/services/actions)
+          - [DEPRECATED] `follow_joint_trajectory_action_name` - Name of the action server for the controller
+          - `use_move_group_action` - Flag that enables execution via MoveGroup action (MoveIt 2)
+                               ExecuteTrajectory action is employed otherwise
+                               together with a separate planning service client
         """
 
         self._node = node
         self._callback_group = callback_group
+
+        # Check for deprecated parameters
+        if execute_via_moveit:
+            self._node.get_logger().warn(
+                "Parameter `execute_via_moveit` is deprecated. Please use `use_move_group_action` instead."
+            )
+            use_move_group_action = True
+        if follow_joint_trajectory_action_name != "joint_trajectory_controller/follow_joint_trajectory":
+            self._node.get_logger().warn(
+                "Parameter `follow_joint_trajectory_action_name` is deprecated. `MoveIt2` uses the `execute_trajectory` action instead."
+            )
 
         # Create subscriber for current joint states
         self._node.create_subscription(

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -1509,6 +1509,7 @@ class MoveIt2:
             )
             return
 
+        self.__last_error_code = None
         self.__is_motion_requested = True
         self.__send_goal_future_move_action = self.__move_action_client.send_goal_async(
             goal=self.__move_action_goal,
@@ -1570,6 +1571,7 @@ class MoveIt2:
             )
             return
 
+        self.__last_error_code = None
         self.__is_motion_requested = True
         self.__send_goal_future_execute_trajectory = self.__execute_trajectory_action_client.send_goal_async(
             goal=goal,

--- a/pymoveit2/moveit2_gripper.py
+++ b/pymoveit2/moveit2_gripper.py
@@ -25,7 +25,8 @@ class MoveIt2Gripper(MoveIt2):
         skip_planning: bool = False,
         skip_planning_fixed_motion_duration: float = 0.5,
         callback_group: Optional[CallbackGroup] = None,
-        follow_joint_trajectory_action_name: str = "gripper_trajectory_controller/follow_joint_trajectory",
+        follow_joint_trajectory_action_name: str = "DEPRECATED",
+        use_move_group_action: bool = False,
     ):
         """
         Construct an instance of `MoveIt2Gripper` interface.
@@ -34,7 +35,7 @@ class MoveIt2Gripper(MoveIt2):
           - `open_gripper_joint_positions` - Configuration of gripper joints when open
           - `closed_gripper_joint_positions` - Configuration of gripper joints when fully closed
           - `gripper_group_name` - Name of the planning group for robot gripper
-          - `execute_via_moveit` - Flag that enables execution via MoveGroup action (MoveIt 2)
+          - [DEPRECATED] `execute_via_moveit` - Flag that enables execution via MoveGroup action (MoveIt 2)
                                    FollowJointTrajectory action (controller) is employed otherwise
                                    together with a separate planning service client
           - `ignore_new_calls_while_executing` - Flag to ignore requests to execute new trajectories
@@ -45,8 +46,22 @@ class MoveIt2Gripper(MoveIt2):
           - `skip_planning_fixed_motion_duration` - Desired duration for the closing and opening motions when
                                                     `skip_planning` mode is enabled.
           - `callback_group` - Optional callback group to use for ROS 2 communication (topics/services/actions)
-          - `follow_joint_trajectory_action_name` - Name of the action server for the controller
+          - [DEPRECATED] `follow_joint_trajectory_action_name` - Name of the action server for the controller
+          - `use_move_group_action` - Flag that enables execution via MoveGroup action (MoveIt 2)
+                               ExecuteTrajectory action is employed otherwise
+                               together with a separate planning service client
         """
+
+        # Check for deprecated parameters
+        if execute_via_moveit:
+            node.get_logger().warn(
+                "Parameter `execute_via_moveit` is deprecated. Please use `use_move_group_action` instead."
+            )
+            use_move_group_action = True
+        if follow_joint_trajectory_action_name != "DEPRECATED":
+            node.get_logger().warn(
+                "Parameter `follow_joint_trajectory_action_name` is deprecated. `MoveIt2` uses the `execute_trajectory` action instead."
+            )
 
         super().__init__(
             node=node,
@@ -54,10 +69,9 @@ class MoveIt2Gripper(MoveIt2):
             base_link_name="",
             end_effector_name="",
             group_name=gripper_group_name,
-            execute_via_moveit=execute_via_moveit,
             ignore_new_calls_while_executing=ignore_new_calls_while_executing,
             callback_group=callback_group,
-            follow_joint_trajectory_action_name=follow_joint_trajectory_action_name,
+            use_move_group_action=use_move_group_action,
         )
         self.__del_redundant_attributes()
 


### PR DESCRIPTION
# Description

The primary goal of this PR is to enable users of `pymoveit2` to plan and/or execute asynchronously. This is useful to allow users to cancel planning/execution calls, and to allow the main thread to continue executing during planning/execution (e.g., we use `pymoveit2` within a [behavior tree framework](https://py-trees.readthedocs.io/en/devel/), so the tree must be able to continue ticking as the robot is moving). 

Changes 1-2 below tackle that primary goal. As part of tackling the primary goal, some additional changes also made sense; those are Changes 3-4, which are justified below.

## Detailed Changes

1. Make action execution (both `MoveGroup` and controller execution) asynchronous. Track the state of the action with a new enum, `MoveIt2State`, and allow users to query the state and cancel execution.
2. Carve out the asynchronous planning logic into another function, `plan_async`, that users of this API can call directly. Create an affiliated `get_trajectory` function that processes the future and returns a trajectory.
3. Make all invocations of `plan`/`plan_async` use the planning service (earlier users could decide whether to use the service or the MoveGroup action with `plan_only=true`).
    1. The reason for this is that the way of interacting with asynchronous actions call is very different from asynch services, since action calls first return a goal handle, whereas service calls directly return a future for the result. This would make the return value of `plan_async`, and how users interact with that return value, quite different depending on whether they invoke the action or the service.
    2. Since this code already has a way to asynchronously call, query, and cancel a `MoveGroup` action (via Change 1 above), I think a better way to re-enable planning-only via MoveGroup would be to allow users to set the `plan_only` property of the MoveGroup goal, and then allow them to invoke `_send_goal_async_move_action` (which is invoked anyway if they use `move_to_pose` or `move_to_configuration`). This is unimplemented — let me know if you’d like it.
4. Replace the `FollowJointTrajectory` action exposed by the controller with the `ExecuteTrajectory` action exposed by MoveIt2.
    1. This is necessary to allow us to cancel the goal via [MoveIt2’s `/trajectory_execution_event` topic](https://github.com/ros-planning/moveit2/blob/0e1e3768b05c370202ec697dfbc8d3718094311a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp#L46). Although we could alternatively cancel the action through the goal handle, the action server is able to reject the cancellation request. This topic provides us a way to more directly stop execution, but it can only be done if we execute using MoveIt’s `ExecuteTrajectory` action.
    2. I don’t think any features are lost with this switch, since MoveIt’s `ExecuteTrajectory` internally calls the controller’s `FollowJointTrajectory` action.

# Testing

- [x] Launch the [simulated panda arm](https://github.com/AndrejOrsula/panda_ign_moveit2): `ros2 launch panda_moveit_config ex_fake_control.launch.py`
- [x] Test `move_to_configuration`:
    - [x] Test the synchronous execution still works: `ros2 run pymoveit2 ex_joint_goal.py --ros-args -p joint_positions:="[1.57, -1.57, 0.0, -1.57, 0.0, 1.57, 0.7854]"`
    - [x] Restore to initial joint positions: `ros2 run pymoveit2 ex_joint_goal.py --ros-args -p joint_positions:="[0.0, -0.7853981633974483, 0.0, -2.356194490192345, 0.0, 1.5707963267948966, 0.7853981633974483]"`
    - [x] Test the asynchronous execution can be successfully canceled: `ros2 run pymoveit2 ex_joint_goal.py --ros-args -p joint_positions:="[1.57, -1.57, 0.0, -1.57, 0.0, 1.57, 0.7854]" -p synchronous:=False -p cancel_after_secs:=1.0`
    - [x] Restore to initial joint positions
    - [x] Test that asynchronous execution succeeds if not canceled: `ros2 run pymoveit2 ex_joint_goal.py --ros-args -p joint_positions:="[1.57, -1.57, 0.0, -1.57, 0.0, 1.57, 0.7854]" -p synchronous:=False -p cancel_after_secs:=-1.0`
- [x] Test `move_to_pose`:
    - [x] Restore to initial joint positions
    - [x] Test the synchronous execution still works: `ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.25, 0.0, 1.0]" -p quat_xyzw:="[0.0, 0.0, 0.0, 1.0]" -p cartesian:=False`
    - [x] Restore to initial joint positions
    - [x] Test the asynchronous execution can be successfully canceled: `ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.25, 0.0, 1.0]" -p quat_xyzw:="[0.0, 0.0, 0.0, 1.0]" -p cartesian:=False -p synchronous:=False -p cancel_after_secs:=1.0`
    - [x] Restore to initial joint positions
    - [x] Test that asynchronous execution succeeds if not canceled: `ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.25, 0.0, 1.0]" -p quat_xyzw:="[0.0, 0.0, 0.0, 1.0]" -p cartesian:=False -p synchronous:=False -p cancel_after_secs:=-1.0`
- [x] Test `gripper`:
    - [x] `ros2 run pymoveit2 ex_gripper.py --ros-args -p action:="open"`
    - [x] `ros2 run pymoveit2 ex_gripper.py --ros-args -p action:="close"`
    - [x] `ros2 run pymoveit2 ex_gripper.py --ros-args -p action:="toggle"`

Further, for our application we have developed [behavior tree behaviors](https://github.com/personalrobotics/ada_feeding/tree/ros2-devel/ada_feeding/ada_feeding/behaviors/moveit2) that use this PR’s changes to asynchronously plan and execute (with `use_move_group_action=False`). We’ve been using those behaviors for months and they have worked reliably.