### PR TITLE
Add Path Constraints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ install(PROGRAMS
     ${EXAMPLES_DIR}/ex_collision_primitive.py
     ${EXAMPLES_DIR}/ex_gripper.py
     ${EXAMPLES_DIR}/ex_joint_goal.py
+    ${EXAMPLES_DIR}/ex_orientation_path_constraint.py
     ${EXAMPLES_DIR}/ex_pose_goal.py
     ${EXAMPLES_DIR}/ex_servo.py
     DESTINATION lib/${PROJECT_NAME}

--- a/examples/ex_orientation_path_constraint.py
+++ b/examples/ex_orientation_path_constraint.py
@@ -24,15 +24,7 @@ def main():
     # Declare parameter for joint positions
     node.declare_parameter(
         "initial_joint_positions",
-        [
-            1.57, 
-            -1.57, 
-            0.0, 
-            -1.57, 
-            0.0, 
-            1.57, 
-            0.7854
-        ],
+        [1.57, -1.57, 0.0, -1.57, 0.0, 1.57, 0.7854],
     )
     node.declare_parameter(
         "goal_joint_positions",
@@ -48,7 +40,7 @@ def main():
     )
     node.declare_parameter("use_orientation_constraint", True)
     node.declare_parameter(
-        "orientation_constraint_quaternion", 
+        "orientation_constraint_quaternion",
         [
             0.5,
             -0.5,
@@ -57,7 +49,7 @@ def main():
         ],
     )
     node.declare_parameter(
-        "orientation_constraint_tolerance", 
+        "orientation_constraint_tolerance",
         [
             3.14159,
             0.5,
@@ -92,26 +84,40 @@ def main():
 
     # Get parameters
     initial_joint_positions = (
-        node.get_parameter("initial_joint_positions").get_parameter_value().double_array_value
+        node.get_parameter("initial_joint_positions")
+        .get_parameter_value()
+        .double_array_value
     )
     goal_joint_positions = (
-        node.get_parameter("goal_joint_positions").get_parameter_value().double_array_value
+        node.get_parameter("goal_joint_positions")
+        .get_parameter_value()
+        .double_array_value
     )
     use_orientation_constraint = (
-        node.get_parameter("use_orientation_constraint").get_parameter_value().bool_value
+        node.get_parameter("use_orientation_constraint")
+        .get_parameter_value()
+        .bool_value
     )
     orientation_constraint_quaternion = (
-        node.get_parameter("orientation_constraint_quaternion").get_parameter_value().double_array_value
+        node.get_parameter("orientation_constraint_quaternion")
+        .get_parameter_value()
+        .double_array_value
     )
     orientation_constraint_tolerance = (
-        node.get_parameter("orientation_constraint_tolerance").get_parameter_value().double_array_value
+        node.get_parameter("orientation_constraint_tolerance")
+        .get_parameter_value()
+        .double_array_value
     )
     orientation_constraint_parameterization = (
-        node.get_parameter("orientation_constraint_parameterization").get_parameter_value().integer_value
+        node.get_parameter("orientation_constraint_parameterization")
+        .get_parameter_value()
+        .integer_value
     )
 
     # Move to initial joint configuration
-    node.get_logger().info(f"Moving to {{joint_positions: {list(initial_joint_positions)}}}")
+    node.get_logger().info(
+        f"Moving to {{joint_positions: {list(initial_joint_positions)}}}"
+    )
     moveit2.move_to_configuration(initial_joint_positions)
     moveit2.wait_until_executed()
 
@@ -125,7 +131,9 @@ def main():
         )
 
     # Move to goal joint configuration
-    node.get_logger().info(f"Moving to {{joint_positions: {list(goal_joint_positions)}}}")
+    node.get_logger().info(
+        f"Moving to {{joint_positions: {list(goal_joint_positions)}}}"
+    )
     moveit2.move_to_configuration(goal_joint_positions)
     moveit2.wait_until_executed()
 

--- a/examples/ex_orientation_path_constraint.py
+++ b/examples/ex_orientation_path_constraint.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+Example of moving to a joint configuration.
+- ros2 run pymoveit2 ex_orientation_path_constraints.py --ros-args -p use_orientation_constraint:=True
+- ros2 run pymoveit2 ex_orientation_path_constraints.py --ros-args -p use_orientation_constraint:=False
+"""
+
+from threading import Thread
+
+import rclpy
+from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.node import Node
+
+from pymoveit2 import MoveIt2, MoveIt2State
+from pymoveit2.robots import panda
+
+
+def main():
+    rclpy.init()
+
+    # Create node for this example
+    node = Node("ex_joint_goal")
+
+    # Declare parameter for joint positions
+    node.declare_parameter(
+        "initial_joint_positions",
+        [
+            1.57, 
+            -1.57, 
+            0.0, 
+            -1.57, 
+            0.0, 
+            1.57, 
+            0.7854
+        ],
+    )
+    node.declare_parameter(
+        "goal_joint_positions",
+        [
+            1.1967347888074664,
+            -1.3973650345565432,
+            0.1342628652196778,
+            -2.508581053909259,
+            -2.412084037045761,
+            0.5267181456160516,
+            1.3027041597804059,
+        ],
+    )
+    node.declare_parameter("use_orientation_constraint", True)
+    node.declare_parameter(
+        "orientation_constraint_quaternion", 
+        [
+            0.5,
+            -0.5,
+            0.5,
+            0.5,
+        ],
+    )
+    node.declare_parameter(
+        "orientation_constraint_tolerance", 
+        [
+            3.14159,
+            0.5,
+            0.5,
+        ],
+    )
+    node.declare_parameter("orientation_constraint_parameterization", 1)
+
+    # Create callback group that allows execution of callbacks in parallel without restrictions
+    callback_group = ReentrantCallbackGroup()
+
+    # Create MoveIt 2 interface
+    moveit2 = MoveIt2(
+        node=node,
+        joint_names=panda.joint_names(),
+        base_link_name=panda.base_link_name(),
+        end_effector_name=panda.end_effector_name(),
+        group_name=panda.MOVE_GROUP_ARM,
+        callback_group=callback_group,
+    )
+
+    # Spin the node in background thread(s) and wait a bit for initialization
+    executor = rclpy.executors.MultiThreadedExecutor(2)
+    executor.add_node(node)
+    executor_thread = Thread(target=executor.spin, daemon=True, args=())
+    executor_thread.start()
+    node.create_rate(1.0).sleep()
+
+    # Scale down velocity and acceleration of joints (percentage of maximum)
+    moveit2.max_velocity = 0.5
+    moveit2.max_acceleration = 0.5
+
+    # Get parameters
+    initial_joint_positions = (
+        node.get_parameter("initial_joint_positions").get_parameter_value().double_array_value
+    )
+    goal_joint_positions = (
+        node.get_parameter("goal_joint_positions").get_parameter_value().double_array_value
+    )
+    use_orientation_constraint = (
+        node.get_parameter("use_orientation_constraint").get_parameter_value().bool_value
+    )
+    orientation_constraint_quaternion = (
+        node.get_parameter("orientation_constraint_quaternion").get_parameter_value().double_array_value
+    )
+    orientation_constraint_tolerance = (
+        node.get_parameter("orientation_constraint_tolerance").get_parameter_value().double_array_value
+    )
+    orientation_constraint_parameterization = (
+        node.get_parameter("orientation_constraint_parameterization").get_parameter_value().integer_value
+    )
+
+    # Move to initial joint configuration
+    node.get_logger().info(f"Moving to {{joint_positions: {list(initial_joint_positions)}}}")
+    moveit2.move_to_configuration(initial_joint_positions)
+    moveit2.wait_until_executed()
+
+    # Set orientation path constraint
+    if use_orientation_constraint:
+        node.get_logger().info(f"Setting orientation path constraint")
+        moveit2.set_path_orientation_constraint(
+            quat_xyzw=orientation_constraint_quaternion,
+            tolerance=orientation_constraint_tolerance,
+            parameterization=orientation_constraint_parameterization,
+        )
+
+    # Move to goal joint configuration
+    node.get_logger().info(f"Moving to {{joint_positions: {list(goal_joint_positions)}}}")
+    moveit2.move_to_configuration(goal_joint_positions)
+    moveit2.wait_until_executed()
+
+    # Shutdown
+    rclpy.shutdown()
+    executor_thread.join()
+    exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -846,8 +846,8 @@ class MoveIt2:
         frame_id: Optional[str] = None,
         target_link: Optional[str] = None,
         tolerance: Union[float, Tuple[float, float, float]] = 0.001,
-        parameterization: int = 0, # 0: Euler, 1: Rotation Vector
         weight: float = 1.0,
+        parameterization: int = 0, # 0: Euler, 1: Rotation Vector
     ):
         """
         Set Cartesian orientation goal of `target_link` with respect to `frame_id`.
@@ -1045,8 +1045,8 @@ class MoveIt2:
         frame_id: Optional[str] = None,
         target_link: Optional[str] = None,
         tolerance: Union[float, Tuple[float, float, float]] = 0.001,
-        parameterization: int = 0, # 0: Euler Angles, 1: Rotation Vector
         weight: float = 1.0,
+        parameterization: int = 0, # 0: Euler Angles, 1: Rotation Vector
     ):
         """
         Set Cartesian orientation goal of `target_link` with respect to `frame_id`.

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -943,7 +943,7 @@ class MoveIt2:
 
         self.__move_action_goal.request.goal_constraints.append(Constraints())
 
-    def set_joint_path(
+    def set_path_joint_constraint(
         self,
         joint_positions: List[float],
         joint_names: Optional[List[str]] = None,
@@ -980,7 +980,7 @@ class MoveIt2:
             # Append to other constraints
             self.__move_action_goal.request.path_constraints.joint_constraints.append(constraint)
 
-    def set_position_path(
+    def set_path_position_constraint(
         self,
         position: Union[Point, Tuple[float, float, float]],
         frame_id: Optional[str] = None,
@@ -1031,7 +1031,7 @@ class MoveIt2:
         # Append to other constraints
         self.__move_action_goal.request.path_constraints.position_constraints.append(constraint)
 
-    def set_orientation_path(
+    def set_path_orientation_constraint(
         self,
         quat_xyzw: Union[Quaternion, Tuple[float, float, float, float]],
         frame_id: Optional[str] = None,

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -845,7 +845,7 @@ class MoveIt2:
         quat_xyzw: Union[Quaternion, Tuple[float, float, float, float]],
         frame_id: Optional[str] = None,
         target_link: Optional[str] = None,
-        tolerance: float = 0.001,
+        tolerance_xyz: Tuple[float, float, float] = [0.001, 0.001, 0.001],
         weight: float = 1.0,
     ):
         """
@@ -875,9 +875,9 @@ class MoveIt2:
             constraint.orientation.w = float(quat_xyzw[3])
 
         # Define tolerances
-        constraint.absolute_x_axis_tolerance = tolerance
-        constraint.absolute_y_axis_tolerance = tolerance
-        constraint.absolute_z_axis_tolerance = tolerance
+        constraint.absolute_x_axis_tolerance = tolerance_xyz[0]
+        constraint.absolute_y_axis_tolerance = tolerance_xyz[1]
+        constraint.absolute_z_axis_tolerance = tolerance_xyz[2]
 
         # Set weight of the constraint
         constraint.weight = weight
@@ -1036,7 +1036,7 @@ class MoveIt2:
         quat_xyzw: Union[Quaternion, Tuple[float, float, float, float]],
         frame_id: Optional[str] = None,
         target_link: Optional[str] = None,
-        tolerance: float = 0.001,
+        tolerance_xyz: Tuple[float, float, float] = [0.001, 0.001, 0.001],
         weight: float = 1.0,
     ):
         """
@@ -1066,9 +1066,9 @@ class MoveIt2:
             constraint.orientation.w = float(quat_xyzw[3])
 
         # Define tolerances
-        constraint.absolute_x_axis_tolerance = tolerance
-        constraint.absolute_y_axis_tolerance = tolerance
-        constraint.absolute_z_axis_tolerance = tolerance
+        constraint.absolute_x_axis_tolerance = tolerance_xyz[0]
+        constraint.absolute_y_axis_tolerance = tolerance_xyz[1]
+        constraint.absolute_z_axis_tolerance = tolerance_xyz[2]
 
         # Set weight of the constraint
         constraint.weight = weight

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -725,7 +725,7 @@ class MoveIt2:
         frame_id: Optional[str] = None,
         target_link: Optional[str] = None,
         tolerance_position: float = 0.001,
-        tolerance_orientation: float = 0.001,
+        tolerance_orientation: Union[float, Tuple[float, float, float]] = 0.001,
         weight_position: float = 1.0,
         weight_orientation: float = 1.0,
     ):

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -845,7 +845,7 @@ class MoveIt2:
         quat_xyzw: Union[Quaternion, Tuple[float, float, float, float]],
         frame_id: Optional[str] = None,
         target_link: Optional[str] = None,
-        tolerance_xyz: Tuple[float, float, float] = [0.001, 0.001, 0.001],
+        tolerance: Union[float, Tuple[float, float, float]] = 0.001,
         weight: float = 1.0,
     ):
         """
@@ -875,6 +875,10 @@ class MoveIt2:
             constraint.orientation.w = float(quat_xyzw[3])
 
         # Define tolerances
+        if type(tolerance) == float:
+            tolerance_xyz = (tolerance, tolerance, tolerance)
+        else:
+            tolerance_xyz = tolerance
         constraint.absolute_x_axis_tolerance = tolerance_xyz[0]
         constraint.absolute_y_axis_tolerance = tolerance_xyz[1]
         constraint.absolute_z_axis_tolerance = tolerance_xyz[2]
@@ -1036,7 +1040,7 @@ class MoveIt2:
         quat_xyzw: Union[Quaternion, Tuple[float, float, float, float]],
         frame_id: Optional[str] = None,
         target_link: Optional[str] = None,
-        tolerance_xyz: Tuple[float, float, float] = [0.001, 0.001, 0.001],
+        tolerance: Union[float, Tuple[float, float, float]] = 0.001,
         weight: float = 1.0,
     ):
         """
@@ -1066,9 +1070,16 @@ class MoveIt2:
             constraint.orientation.w = float(quat_xyzw[3])
 
         # Define tolerances
+        if type(tolerance) == float:
+            tolerance_xyz = (tolerance, tolerance, tolerance)
+        else:
+            tolerance_xyz = tolerance
         constraint.absolute_x_axis_tolerance = tolerance_xyz[0]
         constraint.absolute_y_axis_tolerance = tolerance_xyz[1]
         constraint.absolute_z_axis_tolerance = tolerance_xyz[2]
+
+        # Define the parameterization (how to interpret the tolerance)
+        constraint.parameterization = 0 # 0: Euler Angles, 1: Rotation Vector
 
         # Set weight of the constraint
         constraint.weight = weight

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -461,7 +461,7 @@ class MoveIt2:
         frame_id: Optional[str] = None,
         target_link: Optional[str] = None,
         tolerance_position: float = 0.001,
-        tolerance_orientation: float = 0.001,
+        tolerance_orientation: Union[float, Tuple[float, float, float]] = 0.001,
         tolerance_joint_position: float = 0.001,
         weight_position: float = 1.0,
         weight_orientation: float = 1.0,
@@ -498,7 +498,7 @@ class MoveIt2:
         frame_id: Optional[str] = None,
         target_link: Optional[str] = None,
         tolerance_position: float = 0.001,
-        tolerance_orientation: float = 0.001,
+        tolerance_orientation: Union[float, Tuple[float, float, float]] = 0.001,
         tolerance_joint_position: float = 0.001,
         weight_position: float = 1.0,
         weight_orientation: float = 1.0,
@@ -846,6 +846,7 @@ class MoveIt2:
         frame_id: Optional[str] = None,
         target_link: Optional[str] = None,
         tolerance: Union[float, Tuple[float, float, float]] = 0.001,
+        parameterization: int = 0, # 0: Euler, 1: Rotation Vector
         weight: float = 1.0,
     ):
         """
@@ -882,6 +883,9 @@ class MoveIt2:
         constraint.absolute_x_axis_tolerance = tolerance_xyz[0]
         constraint.absolute_y_axis_tolerance = tolerance_xyz[1]
         constraint.absolute_z_axis_tolerance = tolerance_xyz[2]
+
+        # Define parameterization (how to interpret the tolerance)
+        constraint.parameterization = parameterization
 
         # Set weight of the constraint
         constraint.weight = weight
@@ -1041,6 +1045,7 @@ class MoveIt2:
         frame_id: Optional[str] = None,
         target_link: Optional[str] = None,
         tolerance: Union[float, Tuple[float, float, float]] = 0.001,
+        parameterization: int = 0, # 0: Euler Angles, 1: Rotation Vector
         weight: float = 1.0,
     ):
         """
@@ -1079,7 +1084,7 @@ class MoveIt2:
         constraint.absolute_z_axis_tolerance = tolerance_xyz[2]
 
         # Define the parameterization (how to interpret the tolerance)
-        constraint.parameterization = 0 # 0: Euler Angles, 1: Rotation Vector
+        constraint.parameterization = parameterization
 
         # Set weight of the constraint
         constraint.weight = weight

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -847,7 +847,7 @@ class MoveIt2:
         target_link: Optional[str] = None,
         tolerance: Union[float, Tuple[float, float, float]] = 0.001,
         weight: float = 1.0,
-        parameterization: int = 0, # 0: Euler, 1: Rotation Vector
+        parameterization: int = 0,  # 0: Euler, 1: Rotation Vector
     ):
         """
         Set Cartesian orientation goal of `target_link` with respect to `frame_id`.
@@ -986,7 +986,9 @@ class MoveIt2:
             constraint.weight = weight
 
             # Append to other constraints
-            self.__move_action_goal.request.path_constraints.joint_constraints.append(constraint)
+            self.__move_action_goal.request.path_constraints.joint_constraints.append(
+                constraint
+            )
 
     def set_path_position_constraint(
         self,
@@ -1037,7 +1039,9 @@ class MoveIt2:
         constraint.weight = weight
 
         # Append to other constraints
-        self.__move_action_goal.request.path_constraints.position_constraints.append(constraint)
+        self.__move_action_goal.request.path_constraints.position_constraints.append(
+            constraint
+        )
 
     def set_path_orientation_constraint(
         self,
@@ -1046,7 +1050,7 @@ class MoveIt2:
         target_link: Optional[str] = None,
         tolerance: Union[float, Tuple[float, float, float]] = 0.001,
         weight: float = 1.0,
-        parameterization: int = 0, # 0: Euler Angles, 1: Rotation Vector
+        parameterization: int = 0,  # 0: Euler Angles, 1: Rotation Vector
     ):
         """
         Set Cartesian orientation goal of `target_link` with respect to `frame_id`.
@@ -1090,7 +1094,9 @@ class MoveIt2:
         constraint.weight = weight
 
         # Append to other constraints
-        self.__move_action_goal.request.path_constraints.orientation_constraints.append(constraint)
+        self.__move_action_goal.request.path_constraints.orientation_constraints.append(
+            constraint
+        )
 
     def clear_path_constraints(self):
         """


### PR DESCRIPTION
# Description

MoveIt2 allows planning with path constraints (e.g., see [here](https://moveit.picknik.ai/main/doc/how_to_guides/using_ompl_constrained_planning/ompl_constrained_planning.html)) but `pymoveit2` does not currently support it. This PR does the following:

1. Separates the logic to create constraints from the logic to set goal constraints, so that the constraint creation functions can be reused.
2. Extends the API to allow for setting orientation, position, and joint constraints as path constraints (in addition to the existing option of setting them as goal constraints).
3. Adds an example showcasing the orientation path constraint capability.

Note that this PR is joint with [`panda_ign_moveit2`#29](https://github.com/AndrejOrsula/panda_ign_moveit2/pull/29), which enables [OMPL Constrained Planning](https://moveit.picknik.ai/main/doc/how_to_guides/using_ompl_constrained_planning/ompl_constrained_planning.html) for efficient planning with orientation path constraints.

# Testing
Config:
- [x] Pull the panda config with orientation path constraints enabled: [`panda_ign_moveit2`#29](https://github.com/AndrejOrsula/panda_ign_moveit2/pull/29)
- [x] Pull this branch
- [x] Re-build your workspace
- [x] Launch the [simulated panda arm](https://github.com/AndrejOrsula/panda_ign_moveit2): `ros2 launch panda_moveit_config ex_fake_control.launch.py`

Testing:
- [x] Check the motion without orientation constraints: `ros2 run pymoveit2 ex_orientation_path_constraint.py --ros-args -p use_orientation_constraint:=False`
- [x] Check the motion with orientation constraints, and verify that the end-effector stays flatter than it did without the constraints: `ros2 run pymoveit2 ex_orientation_path_constraint.py --ros-args -p use_orientation_constraint:=True`
- [x] Verify that planning to a goal pose still works: `ros2 run pymoveit2 ex_pose_goal.py`. (Note that planning to a joint goal was already tested in the above examples)

# Future Work

1. Limiting position constraints to a sphere made sense for goal constraints, but no longer makes sense for path constraints (e.g., look at [the tutorial](https://moveit.picknik.ai/main/doc/how_to_guides/using_ompl_constrained_planning/ompl_constrained_planning.html), that uses a box as opposed to a sphere). Thus, future work should generalize position constraints to allow for any Solid Primitive.
2. We currently don't have examples showcasing the use of position and joint path constraints. They should work in theory, given that they reuse the same code used for position/joint goal constraints and orientation path constraints, but that has not been tested. Future work includes adding examples for position and joint path constraints.
