### PR TITLE
Allow users to set `planner_id` and `pipeline_id`

### DIFF
--- a/examples/ex_joint_goal.py
+++ b/examples/ex_joint_goal.py
@@ -38,6 +38,8 @@ def main():
     node.declare_parameter("synchronous", True)
     # If non-positive, don't cancel. Only used if synchronous is False
     node.declare_parameter("cancel_after_secs", 0.0)
+    # Planner ID
+    node.declare_parameter("planner_id", "RRTConnectkConfigDefault")
 
     # Create callback group that allows execution of callbacks in parallel without restrictions
     callback_group = ReentrantCallbackGroup()
@@ -51,6 +53,7 @@ def main():
         group_name=panda.MOVE_GROUP_ARM,
         callback_group=callback_group,
     )
+    moveit2.planner_id = node.get_parameter("planner_id").get_parameter_value().string_value
 
     # Spin the node in background thread(s) and wait a bit for initialization
     executor = rclpy.executors.MultiThreadedExecutor(2)

--- a/examples/ex_joint_goal.py
+++ b/examples/ex_joint_goal.py
@@ -53,7 +53,9 @@ def main():
         group_name=panda.MOVE_GROUP_ARM,
         callback_group=callback_group,
     )
-    moveit2.planner_id = node.get_parameter("planner_id").get_parameter_value().string_value
+    moveit2.planner_id = (
+        node.get_parameter("planner_id").get_parameter_value().string_value
+    )
 
     # Spin the node in background thread(s) and wait a bit for initialization
     executor = rclpy.executors.MultiThreadedExecutor(2)

--- a/examples/ex_pose_goal.py
+++ b/examples/ex_pose_goal.py
@@ -29,6 +29,8 @@ def main():
     node.declare_parameter("synchronous", True)
     # If non-positive, don't cancel. Only used if synchronous is False
     node.declare_parameter("cancel_after_secs", 0.0)
+    # Planner ID
+    node.declare_parameter("planner_id", "RRTConnectkConfigDefault")
 
     # Create callback group that allows execution of callbacks in parallel without restrictions
     callback_group = ReentrantCallbackGroup()
@@ -42,6 +44,7 @@ def main():
         group_name=panda.MOVE_GROUP_ARM,
         callback_group=callback_group,
     )
+    moveit2.planner_id = node.get_parameter("planner_id").get_parameter_value().string_value
 
     # Spin the node in background thread(s) and wait a bit for initialization
     executor = rclpy.executors.MultiThreadedExecutor(2)

--- a/examples/ex_pose_goal.py
+++ b/examples/ex_pose_goal.py
@@ -44,7 +44,9 @@ def main():
         group_name=panda.MOVE_GROUP_ARM,
         callback_group=callback_group,
     )
-    moveit2.planner_id = node.get_parameter("planner_id").get_parameter_value().string_value
+    moveit2.planner_id = (
+        node.get_parameter("planner_id").get_parameter_value().string_value
+    )
 
     # Spin the node in background thread(s) and wait a bit for initialization
     executor = rclpy.executors.MultiThreadedExecutor(2)

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -1116,13 +1116,6 @@ class MoveIt2:
 
         self.__move_action_goal.request.path_constraints = Constraints()
 
-    def set_planner_id(self, planner_id: str):
-        """
-        Set the ID of the planner to be used.
-        """
-
-        self.__move_action_goal.request.planner_id = planner_id
-
     def compute_fk(
         self,
         joint_state: Optional[Union[JointState, List[float]]] = None,
@@ -1940,8 +1933,8 @@ class MoveIt2:
         move_action_goal.request.path_constraints = Constraints()
         # move_action_goal.request.trajectory_constraints = "Ignored"
         # move_action_goal.request.reference_trajectories = "Ignored"
-        # move_action_goal.request.pipeline_id = "Ignored"
-        # move_action_goal.request.planner_id = "Ignored"
+        move_action_goal.request.pipeline_id = ""
+        move_action_goal.request.planner_id = ""
         move_action_goal.request.group_name = group_name
         move_action_goal.request.num_planning_attempts = 5
         move_action_goal.request.allowed_planning_time = 0.5
@@ -2063,6 +2056,21 @@ class MoveIt2:
     def allowed_planning_time(self, value: float):
         self.__move_action_goal.request.allowed_planning_time = value
 
+    @property
+    def pipeline_id(self) -> int:
+        return self.__move_action_goal.request.pipeline_id
+
+    @pipeline_id.setter
+    def pipeline_id(self, value: str):
+        self.__move_action_goal.request.pipeline_id = value
+
+    @property
+    def planner_id(self) -> int:
+        return self.__move_action_goal.request.planner_id
+
+    @planner_id.setter
+    def planner_id(self, value: str):
+        self.__move_action_goal.request.planner_id = value
 
 def init_joint_state(
     joint_names: List[str],

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -2072,6 +2072,7 @@ class MoveIt2:
     def planner_id(self, value: str):
         self.__move_action_goal.request.planner_id = value
 
+
 def init_joint_state(
     joint_names: List[str],
     joint_positions: Optional[List[str]] = None,

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -1116,6 +1116,13 @@ class MoveIt2:
 
         self.__move_action_goal.request.path_constraints = Constraints()
 
+    def set_planner_id(self, planner_id: str):
+        """
+        Set the ID of the planner to be used.
+        """
+
+        self.__move_action_goal.request.planner_id = planner_id
+
     def compute_fk(
         self,
         joint_state: Optional[Union[JointState, List[float]]] = None,


### PR DESCRIPTION
# Description

Currently, `pymoveit2` implicitly uses the default `pipeline_id` and `planner_id` that the robot was configured with. However, for different motions, one may want to use different pipelines/planners. Hence, this PR allows users to configure those properties of the planning calls.

# Testing

- [x] Launch the [simulated panda arm](https://github.com/AndrejOrsula/panda_ign_moveit2) with log_level info: `ros2 launch panda_moveit_config ex_fake_control.launch.py log_level:=info`
- [x] Have the robot move to a joint goal using the default planner. Verify in MoveGroup logs that it uses RRTConnect: `ros2 run pymoveit2 ex_joint_goal.py --ros-args -p joint_positions:="[1.57, -1.57, 0.0, -1.57, 0.0, 1.57, 0.7854]"`
- [x] Restore to initial joint positions: `ros2 run pymoveit2 ex_joint_goal.py --ros-args -p joint_positions:="[0.0, -0.7853981633974483, 0.0, -2.356194490192345, 0.0, 1.5707963267948966, 0.7853981633974483]"`
- [x] Have the robot move to a joint goal using a different planner. Verify in MoveGroup logs that it uses the specified planner (PRMstar): `ros2 run pymoveit2 ex_joint_goal.py --ros-args -p joint_positions:="[1.57, -1.57, 0.0, -1.57, 0.0, 1.57, 0.7854]" -p planner_id:="PRMstarkConfigDefault"`
- [x] Restore to initial positions.
- [x] Have the robot move to a joint goal using the default planner. Verify in MoveGroup logs that it uses RRTConnect: `ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.25, 0.0, 1.0]" -p quat_xyzw:="[0.0, 0.0, 0.0, 1.0]" -p cartesian:=False`
- [x] Restore to initial joint positions.
- [x] Have the robot move to a joint goal using a different planner. Verify in MoveGroup logs that it uses the specified planner (PRMstar): `ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.25, 0.0, 1.0]" -p quat_xyzw:="[0.0, 0.0, 0.0, 1.0]" -p cartesian:=False -p planner_id:="PRMstarkConfigDefault"`