### PR TITLE
Allow users to (dis)allow collisions with an object

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ ament_python_install_package(pymoveit2)
 # Install examples
 set(EXAMPLES_DIR examples)
 install(PROGRAMS
+    ${EXAMPLES_DIR}/ex_allow_collisions.py
     ${EXAMPLES_DIR}/ex_collision_mesh.py
     ${EXAMPLES_DIR}/ex_collision_primitive.py
     ${EXAMPLES_DIR}/ex_fk.py

--- a/examples/ex_allow_collisions.py
+++ b/examples/ex_allow_collisions.py
@@ -58,7 +58,7 @@ def main():
     # (Dis)allow collisions
     moveit2.allow_collisions(object_id, allow)
     node.get_logger().info(
-        f"{'Allow' if allow else 'Disallow'}ed collisions between all obejcts and '{object_id}'"
+        f"{'Allow' if allow else 'Disallow'}ed collisions between all objects and '{object_id}'"
     )
 
     rclpy.shutdown()

--- a/examples/ex_allow_collisions.py
+++ b/examples/ex_allow_collisions.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+Example of adding and removing a collision object with a primitive geometry.
+- ros2 run pymoveit2 ex_allow_collisions.py --ros-args -p id:="sphere" -p allow:=true
+- ros2 run pymoveit2 ex_allow_collisions.py --ros-args -p id:="sphere" -p allow:=false
+"""
+
+from threading import Thread
+
+import rclpy
+from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.node import Node
+
+from pymoveit2 import MoveIt2
+from pymoveit2.robots import panda
+
+
+def main():
+    rclpy.init()
+
+    # Create node for this example
+    node = Node("ex_allow_collisions")
+
+    # Declare parameter for joint positions
+    node.declare_parameter(
+        "id",
+        "box",
+    )
+    node.declare_parameter(
+        "allow",
+        True,
+    )
+
+    # Create callback group that allows execution of callbacks in parallel without restrictions
+    callback_group = ReentrantCallbackGroup()
+
+    # Create MoveIt 2 interface
+    moveit2 = MoveIt2(
+        node=node,
+        joint_names=panda.joint_names(),
+        base_link_name=panda.base_link_name(),
+        end_effector_name=panda.end_effector_name(),
+        group_name=panda.MOVE_GROUP_ARM,
+        callback_group=callback_group,
+    )
+
+    # Spin the node in background thread(s) and wait a bit for initialization
+    executor = rclpy.executors.MultiThreadedExecutor(2)
+    executor.add_node(node)
+    executor_thread = Thread(target=executor.spin, daemon=True, args=())
+    executor_thread.start()
+    node.create_rate(1.0).sleep()
+
+    # Get parameters
+    object_id = node.get_parameter("id").get_parameter_value().string_value
+    allow = node.get_parameter("allow").get_parameter_value().bool_value
+
+    # (Dis)allow collisions
+    moveit2.allow_collisions(object_id, allow)
+    node.get_logger().info(
+        f"{'Allow' if allow else 'Disallow'}ed collisions between all obejcts and '{object_id}'"
+    )
+
+    rclpy.shutdown()
+    executor_thread.join()
+    exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ex_allow_collisions.py
+++ b/examples/ex_allow_collisions.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
-Example of adding and removing a collision object with a primitive geometry.
+Example of (dis)allowing collisions between the robot object and an object with
+the specified ID.
 - ros2 run pymoveit2 ex_allow_collisions.py --ros-args -p id:="sphere" -p allow:=true
 - ros2 run pymoveit2 ex_allow_collisions.py --ros-args -p id:="sphere" -p allow:=false
 """

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -1916,6 +1916,7 @@ class MoveIt2:
             )
             return
 
+        self.__last_error_code = None
         self.__is_motion_requested = True
         self.__send_goal_future_move_action = self.__move_action_client.send_goal_async(
             goal=self.__move_action_goal,
@@ -1977,6 +1978,7 @@ class MoveIt2:
             )
             return
 
+        self.__last_error_code = None
         self.__is_motion_requested = True
         self.__send_goal_future_execute_trajectory = (
             self._execute_trajectory_action_client.send_goal_async(

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -1733,7 +1733,7 @@ class MoveIt2:
         ).scene
         return True
 
-    def allow_collisions(self, id: str, allow: bool) -> bool:
+    def allow_collisions(self, id: str, allow: bool) -> Optional[Future]:
         """
         Takes in the ID of an element in the planning scene. Modifies the allowed
         collision matrix to (dis)allow collisions between that object and all other
@@ -1747,7 +1747,7 @@ class MoveIt2:
         """
         # Update the planning scene
         if not self.__update_planning_scene():
-            return False
+            return None
         allowed_collision_matrix = self.__planning_scene.allowed_collision_matrix
         self.__old_allowed_collision_matrix = copy.deepcopy(allowed_collision_matrix)
 
@@ -1777,7 +1777,7 @@ class MoveIt2:
             self._node.get_logger().warn(
                 f"Service '{self._apply_planning_scene_service.srv_name}' is not yet available. Better luck next time!"
             )
-            return False
+            return None
         return self._apply_planning_scene_service.call_async(
             ApplyPlanningScene.Request(
                 scene=self.__planning_scene


### PR DESCRIPTION
# Description

This PR extendes `pymoveit2` to allow users to (dis)allow collisions between one object and all other objects. In practice, this is useful because a robot typically consists of many objects/links, so instead of specifying every object ID for a robot part that we want to (dis)allow collisions with, it is easier to just (dis)allow collisions with all objects, which includes the whole robot.

# Testing

- [x] Launch the [simulated panda arm](https://github.com/AndrejOrsula/panda_ign_moveit2): `ros2 launch panda_moveit_config ex_fake_control.launch.py`
- [x] Add a collision object to the planning scene: `ros2 run pymoveit2 ex_collision_primitive.py --ros-args -p shape:="sphere" -p position:="[0.5, 0.0, 0.5]" -p dimensions:="[0.04]"`
- [x] In RVIZ, move the robot arm to the collision object, and verify that it turns red (indicating a collision). Plan and verify it fails.
- [x] Allow collisions with that object: `ros2 run pymoveit2 ex_allow_collisions.py --ros-args -p id:="sphere" -p allow:=true`
- [x] In RVIZ, plan to the same arm configuration and verify it succeeds.
- [x] Disallow collisions with that object: `ros2 run pymoveit2 ex_allow_collisions.py --ros-args -p id:="sphere" -p allow:=false`
- [x] In RVIZ, verify that the colliding parts of the robot arm turned red again.

# Notes / Future Work
- Note that although (dis)allowing collisions is asynchronous, within the call it synchronously waits for the planning scene. This should be improved in the future to make it a fully asynchronous call (maybe `pymoveit2` subscribes to the MoveGroup's published planning scene topic so it constantly maintains an upt-to-date planning scene?).
- This PR (dis)allows collisions between one object and all other objects, which was sufficient for our use case. Extending this to more granularly (dis)allowing collisions between pairs of objects should be straightforward.