### PR TITLE
Added setting of cartesian speed and acceleration 

### DIFF
--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -2042,14 +2042,6 @@ class MoveIt2:
         self.__move_action_goal.request.max_acceleration_scaling_factor = value
 
     @property
-    def max_cartesian_speed(self) -> float:
-        return self.__move_action_goal.request.max_cartesian_speed
-
-    @max_cartesian_speed.setter
-    def max_cartesian_speed(self, value: float):
-        self.__move_action_goal.request.max_cartesian_speed = value
-
-    @property
     def num_planning_attempts(self) -> int:
         return self.__move_action_goal.request.num_planning_attempts
 

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -1739,6 +1739,15 @@ class MoveIt2:
         self.__cartesian_path_request.start_state = (
             self.__move_action_goal.request.start_state
         )
+
+        self.__cartesian_path_request.max_velocity_scaling_factor = (
+            self.__move_action_goal.request.max_velocity_scaling_factor
+        )
+
+        self.__cartesian_path_request.max_acceleration_scaling_factor = (
+            self.__move_action_goal.request.max_acceleration_scaling_factor
+        )
+
         self.__cartesian_path_request.group_name = (
             self.__move_action_goal.request.group_name
         )


### PR DESCRIPTION
# Description
This PR fixes the issue #45 by changing the max_cartesian_speed setter to set the max_velocity_scaling_factor of the cartesian_path_request.
This PR also adds a max_cartesian_acceleration setter and getter to set the max_acceleration_scaling_factor of the cartesian_path_request.

# Testing
Tested with a real and simulated franka panda robot via the move_to_pose command with the cartesian flag set to true.
I used the BiTRRT algorithm from the OMPL and the PTP algorithm from the PILZ trajectory generator.
