### PR TITLE
Use `cartesian_speed_limited_link` instead of `cartesian_speed_end_effector_link` when available

### DIFF
--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -1940,7 +1940,11 @@ class MoveIt2:
         move_action_goal.request.allowed_planning_time = 0.5
         move_action_goal.request.max_velocity_scaling_factor = 0.0
         move_action_goal.request.max_acceleration_scaling_factor = 0.0
-        move_action_goal.request.cartesian_speed_limited_link = end_effector
+        # Note: Attribute was renamed in Iron (https://github.com/ros-planning/moveit_msgs/pull/130)
+        if hasattr(move_action_goal.request, "cartesian_speed_limited_link"):
+            move_action_goal.request.cartesian_speed_limited_link = end_effector
+        else:
+            move_action_goal.request.cartesian_speed_end_effector_link = end_effector
         move_action_goal.request.max_cartesian_speed = 0.0
 
         # move_action_goal.planning_options.planning_scene_diff = "Ignored"

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -1940,7 +1940,7 @@ class MoveIt2:
         move_action_goal.request.allowed_planning_time = 0.5
         move_action_goal.request.max_velocity_scaling_factor = 0.0
         move_action_goal.request.max_acceleration_scaling_factor = 0.0
-        move_action_goal.request.cartesian_speed_end_effector_link = end_effector
+        move_action_goal.request.cartesian_speed_limited_link = end_effector
         move_action_goal.request.max_cartesian_speed = 0.0
 
         # move_action_goal.planning_options.planning_scene_diff = "Ignored"


### PR DESCRIPTION
- Continues https://github.com/AndrejOrsula/pymoveit2/pull/49 based on the discussion there
- Fixes https://github.com/AndrejOrsula/pymoveit2/issues/55