### PR TITLE
Allow users to set various cartesian path service parameters

### DIFF
--- a/examples/ex_pose_goal.py
+++ b/examples/ex_pose_goal.py
@@ -25,12 +25,17 @@ def main():
     # Declare parameters for position and orientation
     node.declare_parameter("position", [0.5, 0.0, 0.25])
     node.declare_parameter("quat_xyzw", [1.0, 0.0, 0.0, 0.0])
-    node.declare_parameter("cartesian", False)
     node.declare_parameter("synchronous", True)
     # If non-positive, don't cancel. Only used if synchronous is False
     node.declare_parameter("cancel_after_secs", 0.0)
     # Planner ID
     node.declare_parameter("planner_id", "RRTConnectkConfigDefault")
+    # Declare parameters for cartesian planning
+    node.declare_parameter("cartesian", False)
+    node.declare_parameter("cartesian_max_step", 0.0025)
+    node.declare_parameter("cartesian_fraction_threshold", 0.0)
+    node.declare_parameter("cartesian_jump_threshold", 0.0)
+    node.declare_parameter("cartesian_avoid_collisions", False)
 
     # Create callback group that allows execution of callbacks in parallel without restrictions
     callback_group = ReentrantCallbackGroup()
@@ -62,17 +67,45 @@ def main():
     # Get parameters
     position = node.get_parameter("position").get_parameter_value().double_array_value
     quat_xyzw = node.get_parameter("quat_xyzw").get_parameter_value().double_array_value
-    cartesian = node.get_parameter("cartesian").get_parameter_value().bool_value
     synchronous = node.get_parameter("synchronous").get_parameter_value().bool_value
     cancel_after_secs = (
         node.get_parameter("cancel_after_secs").get_parameter_value().double_value
     )
+    cartesian = node.get_parameter("cartesian").get_parameter_value().bool_value
+    cartesian_max_step = (
+        node.get_parameter("cartesian_max_step").get_parameter_value().double_value
+    )
+    cartesian_fraction_threshold = (
+        node.get_parameter("cartesian_fraction_threshold")
+        .get_parameter_value()
+        .double_value
+    )
+    cartesian_jump_threshold = (
+        node.get_parameter("cartesian_jump_threshold")
+        .get_parameter_value()
+        .double_value
+    )
+    cartesian_avoid_collisions = (
+        node.get_parameter("cartesian_avoid_collisions")
+        .get_parameter_value()
+        .bool_value
+    )
+
+    # Set parameters for cartesian planning
+    moveit2.cartesian_avoid_collisions = cartesian_avoid_collisions
+    moveit2.cartesian_jump_threshold = cartesian_jump_threshold
 
     # Move to pose
     node.get_logger().info(
         f"Moving to {{position: {list(position)}, quat_xyzw: {list(quat_xyzw)}}}"
     )
-    moveit2.move_to_pose(position=position, quat_xyzw=quat_xyzw, cartesian=cartesian)
+    moveit2.move_to_pose(
+        position=position,
+        quat_xyzw=quat_xyzw,
+        cartesian=cartesian,
+        cartesian_max_step=cartesian_max_step,
+        cartesian_fraction_threshold=cartesian_fraction_threshold,
+    )
     if synchronous:
         # Note: the same functionality can be achieved by setting
         # `synchronous:=false` and `cancel_after_secs` to a negative value.

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -2192,6 +2192,12 @@ class MoveIt2:
     def planner_id(self, value: str):
         self.__move_action_goal.request.planner_id = value
 
+    def cartesian_avoid_collisions(self) -> bool:
+        return self.__cartesian_path_request.request.avoid_collisions
+
+    @cartesian_avoid_collisions.setter
+    def cartesian_avoid_collisions(self, value: bool):
+        self.__cartesian_path_request.avoid_collisions = value
 
 def init_joint_state(
     joint_names: List[str],

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -2217,6 +2217,22 @@ class MoveIt2:
         self.__cartesian_path_request.jump_threshold = value
 
     @property
+    def cartesian_prismatic_jump_threshold(self) -> float:
+        return self.__cartesian_path_request.request.prismatic_jump_threshold
+
+    @cartesian_prismatic_jump_threshold.setter
+    def cartesian_prismatic_jump_threshold(self, value: float):
+        self.__cartesian_path_request.prismatic_jump_threshold = value
+
+    @property
+    def cartesian_revolute_jump_threshold(self) -> float:
+        return self.__cartesian_path_request.request.revolute_jump_threshold
+
+    @cartesian_revolute_jump_threshold.setter
+    def cartesian_revolute_jump_threshold(self, value: float):
+        self.__cartesian_path_request.revolute_jump_threshold = value
+
+    @property
     def pipeline_id(self) -> int:
         return self.__move_action_goal.request.pipeline_id
 

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -518,7 +518,6 @@ class MoveIt2:
 
         return self.get_trajectory(future, cartesian=cartesian)
 
-
     def plan_async(
         self,
         pose: Optional[Union[PoseStamped, Pose]] = None,
@@ -664,7 +663,7 @@ class MoveIt2:
         For cartesian plans, the plan is rejected if the fraction of the path that was completed is
         less than `cartesian_fraction_threshold`.
         """
-        if (not future.done()):
+        if not future.done():
             self._node.get_logger().warn(
                 "Cannot get trajectory because future is not done."
             )
@@ -688,7 +687,7 @@ class MoveIt2:
                     f"Planning failed! Error code: {res.error_code.val}."
                 )
                 return None
-        
+
         # Else Kinematic
         res = res.motion_plan_response
         if MoveItErrorCodes.SUCCESS == res.error_code.val:
@@ -2247,6 +2246,7 @@ class MoveIt2:
     @planner_id.setter
     def planner_id(self, value: str):
         self.__move_action_goal.request.planner_id = value
+
 
 def init_joint_state(
     joint_names: List[str],

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -2177,6 +2177,14 @@ class MoveIt2:
         self.__move_action_goal.request.allowed_planning_time = value
 
     @property
+    def cartesian_avoid_collisions(self) -> bool:
+        return self.__cartesian_path_request.request.avoid_collisions
+
+    @cartesian_avoid_collisions.setter
+    def cartesian_avoid_collisions(self, value: bool):
+        self.__cartesian_path_request.avoid_collisions = value
+
+    @property
     def pipeline_id(self) -> int:
         return self.__move_action_goal.request.pipeline_id
 
@@ -2191,13 +2199,6 @@ class MoveIt2:
     @planner_id.setter
     def planner_id(self, value: str):
         self.__move_action_goal.request.planner_id = value
-
-    def cartesian_avoid_collisions(self) -> bool:
-        return self.__cartesian_path_request.request.avoid_collisions
-
-    @cartesian_avoid_collisions.setter
-    def cartesian_avoid_collisions(self, value: bool):
-        self.__cartesian_path_request.avoid_collisions = value
 
 def init_joint_state(
     joint_names: List[str],

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -2185,6 +2185,14 @@ class MoveIt2:
         self.__cartesian_path_request.avoid_collisions = value
 
     @property
+    def cartesian_jump_threshold(self) -> float:
+        return self.__cartesian_path_request.request.jump_threshold
+
+    @cartesian_jump_threshold.setter
+    def cartesian_jump_threshold(self, value: float):
+        self.__cartesian_path_request.jump_threshold = value
+
+    @property
     def pipeline_id(self) -> int:
         return self.__move_action_goal.request.pipeline_id
 

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -537,6 +537,7 @@ class MoveIt2:
         weight_joint_position: float = 1.0,
         start_joint_state: Optional[Union[JointState, List[float]]] = None,
         cartesian: bool = False,
+        max_step: float = 0.0025,
     ) -> Optional[Future]:
         """
         Plan motion based on previously set goals. Optional arguments can be passed in to
@@ -636,7 +637,8 @@ class MoveIt2:
             future = self._plan_cartesian_path(
                 frame_id=pose_stamped.header.frame_id
                 if pose_stamped is not None
-                else frame_id
+                else frame_id,
+                max_step=max_step,
             )
         else:
             # Use service

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -344,6 +344,8 @@ class MoveIt2:
         weight_position: float = 1.0,
         cartesian: bool = False,
         weight_orientation: float = 1.0,
+        cartesian_max_step: float = 0.0025,
+        cartesian_fraction_threshold: float = 0.0,
     ):
         """
         Plan and execute motion based on previously set goals. Optional arguments can be
@@ -428,6 +430,8 @@ class MoveIt2:
                     weight_position=weight_position,
                     weight_orientation=weight_orientation,
                     cartesian=cartesian,
+                    max_step=cartesian_max_step,
+                    cartesian_fraction_threshold=cartesian_fraction_threshold,
                 )
             )
 
@@ -500,12 +504,18 @@ class MoveIt2:
         weight_joint_position: float = 1.0,
         start_joint_state: Optional[Union[JointState, List[float]]] = None,
         cartesian: bool = False,
+        max_step: float = 0.0025,
+        cartesian_fraction_threshold: float = 0.0,
     ) -> Optional[JointTrajectory]:
         """
         Call plan_async and wait on future
         """
         future = self.plan_async(
-            **{key: value for key, value in locals().items() if key != "self"}
+            **{
+                key: value
+                for key, value in locals().items()
+                if key not in ["self", "cartesian_fraction_threshold"]
+            }
         )
 
         if future is None:
@@ -516,7 +526,11 @@ class MoveIt2:
         while not future.done():
             rate.sleep()
 
-        return self.get_trajectory(future, cartesian=cartesian)
+        return self.get_trajectory(
+            future,
+            cartesian=cartesian,
+            cartesian_fraction_threshold=cartesian_fraction_threshold,
+        )
 
     def plan_async(
         self,

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -635,10 +635,10 @@ class MoveIt2:
         # Plan trajectory asynchronously by service call
         if cartesian:
             future = self._plan_cartesian_path(
+                max_step=max_step,
                 frame_id=pose_stamped.header.frame_id
                 if pose_stamped is not None
                 else frame_id,
-                max_step=max_step,
             )
         else:
             # Use service

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -2138,6 +2138,14 @@ class MoveIt2:
         return self.__follow_joint_trajectory_action_client
 
     @property
+    def end_effector_name(self) -> str:
+        return self.__end_effector_name
+
+    @property
+    def base_link_name(self) -> str:
+        return self.__base_link_name
+
+    @property
     def joint_names(self) -> List[str]:
         return self.__joint_names
 


### PR DESCRIPTION
# Description

The PR adds various parameters that allow users to control the behavior of cartesian planning. This includes:
- Allow users to change the `avoid_collisions`, `jump_threshold`, `prismatic_jump_threshold`, and `revolute_jump_threshold` attributes of [the cartesian path service call](https://github.com/ros-planning/moveit_msgs/blob/humble/srv/GetCartesianPath.srv).
- Allow users to specify what fraction of the path must be completed in order to accept the solution.
- Allow users to set the `max_step` from `_plan_async(…)`
- Allow users to access the robot’s end effector name and base link name.

Note that unfortunately, [MoveIt2’s ROS interface does not currently support revolute or prismatic jump thresholds](https://github.com/ros-planning/moveit2/issues/2404).

# Testing

- [x] Launch the [simulated panda arm](https://github.com/AndrejOrsula/panda_ign_moveit2): `ros2 launch panda_moveit_config ex_fake_control.launch.py`
- [x] Test `max_step`:
    - [x] Default movement: `ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.573, 0.000, 0.488]" -p quat_xyzw:="[1.000, -0.000, 0.001, -0.000]" -p cartesian:=True`, verify it succeeds
    - [x] Reset: `ros2 run pymoveit2 ex_joint_goal.py --ros-args -p joint_positions:="[0.0, -0.7853981633974483, 0.0, -2.356194490192345, 0.0, 1.5707963267948966, 0.7853981633974483]"`
    - [x] Invalid parameter: `ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.573, 0.000, 0.488]" -p quat_xyzw:="[1.000, -0.000, 0.001, -0.000]" -p cartesian:=True -p cartesian_max_step:=0.0`, verify it fails
    - [x] Reset
    - [x] Largest max_step: `ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.573, 0.000, 0.488]" -p quat_xyzw:="[1.000, -0.000, 0.001, -0.000]" -p cartesian:=True -p cartesian_max_step:=0.3`, verify it succeeds
    - [x] Reset
- [x] Text `cartesian_jump_threshold`:
    - [x] Small jump threshold: `ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.573, 0.000, 0.488]" -p quat_xyzw:="[1.000, -0.000, 0.001, -0.000]" -p cartesian:=True -p cartesian_jump_threshold:=0.001`, verify that the planning/execution call succeeds but the arm does not actually move.
    - [x] Reset
    - [x] Medium jump threshold: `ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.573, 0.000, 0.488]" -p quat_xyzw:="[1.000, -0.000, 0.001, -0.000]" -p cartesian:=True -p cartesian_jump_threshold:=1.0`, verify that it gets almost to the goal but not quite.
    - [x] Reset
    - [x] Large jump threshold: `ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.573, 0.000, 0.488]" -p quat_xyzw:="[1.000, -0.000, 0.001, -0.000]" -p cartesian:=True -p cartesian_jump_threshold:=2.0`, verify that it gets to the goal.
    - [x] Reset
- [x] Test `cartesian_fraction_threshold`:
    - [x] High threshold that can be reached: `ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.573, 0.000, 0.488]" -p quat_xyzw:="[1.000, -0.000, 0.001, -0.000]" -p cartesian:=True -p cartesian_fraction_threshold:=1.0`, verify it succeeds
    - [x] Reset
    - [x] High threshold that cannot be reached: `ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.573, 0.000, 0.488]" -p quat_xyzw:="[1.000, -0.000, 0.001, -0.000]" -p cartesian:=True -p cartesian_jump_threshold:=1.0 -p cartesian_fraction_threshold:=1.0`, verify it fails
    - [x] Reset
    - [x] Impossible threshold: `ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.573, 0.000, 0.488]" -p quat_xyzw:="[1.000, -0.000, 0.001, -0.000]" -p cartesian:=True -p cartesian_fraction_threshold:=1.1`, verify it fails
    - [x] Reset
- [x] Test `cartesian_avoid_collisions`:
    - [x] Test without a collision object: `ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.573, 0.000, 0.488]" -p quat_xyzw:="[1.000, -0.000, 0.001, -0.000]" -p cartesian:=True -p cartesian_avoid_collisions:=True`, verify it succeeds
    - [x] Reset
    - [x] Add a collision object: `ros2 run pymoveit2 ex_collision_primitive.py --ros-args -p shape:="sphere" -p position:="[0.573, 0.000, 0.488]" -p dimensions:="[0.04]"`
    - [x] Test with a collision object: `ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.573, 0.000, 0.488]" -p quat_xyzw:="[1.000, -0.000, 0.001, -0.000]" -p cartesian:=True -p cartesian_avoid_collisions:=True`, verify it stops before the collision
    - [x] Reset
    - [x] Test without avoiding collisions: `ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.573, 0.000, 0.488]" -p quat_xyzw:="[1.000, -0.000, 0.001, -0.000]" -p cartesian:=True -p cartesian_avoid_collisions:=False`, verify it goes all the way to the goal, ignoring the collision.
