### PR TITLE
Allow Scaling Collision Meshes

### DIFF
--- a/examples/ex_collision_mesh.py
+++ b/examples/ex_collision_mesh.py
@@ -2,7 +2,7 @@
 """
 Example of adding and removing a collision object with a mesh geometry.
 Note: Python module `trimesh` is required for this example (`pip install trimesh`).
-- ros2 run pymoveit2 ex_collision_mesh.py --ros-args -p position:="[0.5, 0.0, 0.5]" -p quat_xyzw:="[0.0, 0.0, -0.7071, 0.7071]"
+- ros2 run pymoveit2 ex_collision_mesh.py --ros-args -p position:="[0.5, 0.0, 0.5]" -p quat_xyzw:="[0.0, 0.0, -0.7071, 0.7071]" -p scale:="[1.0, 1.0, 1.0]"
 - ros2 run pymoveit2 ex_collision_mesh.py --ros-args -p action:="move" -p position:="[0.2, 0.0, 0.2]"
 - ros2 run pymoveit2 ex_collision_mesh.py --ros-args -p filepath:="./my_favourity_mesh.stl"
 - ros2 run pymoveit2 ex_collision_mesh.py --ros-args -p action:="remove"
@@ -40,6 +40,7 @@ def main():
     )
     node.declare_parameter("position", [0.5, 0.0, 0.5])
     node.declare_parameter("quat_xyzw", [0.0, 0.0, -0.7071, 0.7071])
+    node.declare_parameter("scale", [1.0, 1.0, 1.0])
 
     # Create callback group that allows execution of callbacks in parallel without restrictions
     callback_group = ReentrantCallbackGroup()
@@ -66,10 +67,13 @@ def main():
     action = node.get_parameter("action").get_parameter_value().string_value
     position = node.get_parameter("position").get_parameter_value().double_array_value
     quat_xyzw = node.get_parameter("quat_xyzw").get_parameter_value().double_array_value
+    scale = node.get_parameter("scale").get_parameter_value().double_array_value
 
     # Use the default example mesh if invalid
     if not filepath:
-        node.get_logger().info(f"Using the default example mesh file")
+        node.get_logger().info(
+            f"Using the default example mesh file {DEFAULT_EXAMPLE_MESH}"
+        )
         filepath = DEFAULT_EXAMPLE_MESH
 
     # Make sure the mesh file exists
@@ -92,6 +96,7 @@ def main():
             id=object_id,
             position=position,
             quat_xyzw=quat_xyzw,
+            scale=scale,
         )
     elif action == "remove":
         # Remove collision mesh

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
   <exec_depend>control_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>moveit_msgs</exec_depend>
+  <exec_depend>python3-trimesh-pip</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>shape_msgs</exec_depend>

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -24,6 +24,7 @@ from moveit_msgs.srv import (
     GetPositionFK,
     GetPositionIK,
 )
+import numpy as np
 from rclpy.action import ActionClient
 from rclpy.callback_groups import CallbackGroup
 from rclpy.node import Node
@@ -1618,12 +1619,14 @@ class MoveIt2:
         ] = None,
         frame_id: Optional[str] = None,
         operation: int = CollisionObject.ADD,
+        scale: Union[float, Tuple[float, float, float]] = 1.0,
     ):
         """
         Add collision object with a mesh geometry specified by `filepath`.
         Note: This function required 'trimesh' Python module to be installed.
         """
 
+        # Load the mesh
         try:
             import trimesh
         except ImportError as err:
@@ -1679,6 +1682,14 @@ class MoveIt2:
         )
 
         mesh = trimesh.load(filepath)
+
+        # Scale the mesh
+        if isinstance(scale, float):
+            scale = (scale, scale, scale)
+        transform = np.eye(4)
+        transform.fill_diagonal(scale)
+        mesh.apply_transform(transform)
+
         msg.meshes.append(
             Mesh(
                 triangles=[MeshTriangle(vertex_indices=face) for face in mesh.faces],

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -3,6 +3,7 @@ import threading
 from enum import Enum
 from typing import List, Optional, Tuple, Union
 
+import numpy as np
 from action_msgs.msg import GoalStatus
 from geometry_msgs.msg import Point, Pose, PoseStamped, Quaternion
 from moveit_msgs.action import ExecuteTrajectory, MoveGroup
@@ -24,7 +25,6 @@ from moveit_msgs.srv import (
     GetPositionFK,
     GetPositionIK,
 )
-import numpy as np
 from rclpy.action import ActionClient
 from rclpy.callback_groups import CallbackGroup
 from rclpy.node import Node
@@ -1687,7 +1687,7 @@ class MoveIt2:
         if isinstance(scale, float):
             scale = (scale, scale, scale)
         transform = np.eye(4)
-        transform.fill_diagonal(scale)
+        np.fill_diagonal(transform, scale)
         mesh.apply_transform(transform)
 
         msg.meshes.append(


### PR DESCRIPTION
# Description

This PR allows users to scale a collision mesh when adding it into the planning scene. Note that scaling occurs within the mesh's XYZ axes.

This PR also adds `trimesh` as a dependency. Although it is not a required dependency (it is only necessary when using meshes), I think it is beneficial to add so that all possible dependencies can be installed with a single `rosdep` call.

# Testing

- [x] Launch the [simulated panda arm](https://github.com/AndrejOrsula/panda_ign_moveit2): `ros2 launch panda_moveit_config ex_fake_control.launch.py`
- [x] Add a collision mesh, verify it is the expected scale: `ros2 run pymoveit2 ex_collision_mesh.py --ros-args -p position:="[0.5, 0.0, 0.5]" -p quat_xyzw:="[0.0, 0.0, -0.7071, 0.7071]"`
- [x] Re-add the collision mesh with a scaled X, verify it updates as expected in RVIZ: `ros2 run pymoveit2 ex_collision_mesh.py --ros-args -p position:="[0.5, 0.0, 0.5]" -p quat_xyzw:="[0.0, 0.0, -0.7071, 0.7071]" -p scale:="[0.5, 1.0, 1.0]"`
- [x] Re-add the collision mesh with a scaled Y, verify it updates as expected in RVIZ: `ros2 run pymoveit2 ex_collision_mesh.py --ros-args -p position:="[0.5, 0.0, 0.5]" -p quat_xyzw:="[0.0, 0.0, -0.7071, 0.7071]" -p scale:="[0.5, 2.0, 1.0]"`
- [x] Re-add the collision mesh with a scaled X, verify it updates as expected in RVIZ: `ros2 run pymoveit2 ex_collision_mesh.py --ros-args -p position:="[0.5, 0.0, 0.5]" -p quat_xyzw:="[0.0, 0.0, -0.7071, 0.7071]" -p scale:="[0.5, 2.0, 5.0]"`