### PR TITLE
Fix bug in cartesian planning

### DIFF
--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -1936,11 +1936,11 @@ class MoveIt2:
         )
 
         # The below attributes were introduced in Iron and do not exist in Humble.
-        if hasattr(__cartesian_path_request, "max_velocity_scaling_factor"):
+        if hasattr(self.__cartesian_path_request, "max_velocity_scaling_factor"):
             self.__cartesian_path_request.max_velocity_scaling_factor = (
                 self.__move_action_goal.request.max_velocity_scaling_factor
             )
-        if hasattr(__cartesian_path_request, "max_acceleration_scaling_factor"):
+        if hasattr(self.__cartesian_path_request, "max_acceleration_scaling_factor"):
             self.__cartesian_path_request.max_acceleration_scaling_factor = (
                 self.__move_action_goal.request.max_acceleration_scaling_factor
             )


### PR DESCRIPTION
My previous PR, #66 , was not thoroughly tested and introduced a bug. This PR resolves that bug, and thoroughly tests it this time. Sorry for overlooking the bug!

# Testing

- [x] Launch the [simulated panda arm](https://github.com/AndrejOrsula/panda_ign_moveit2): `ros2 launch panda_moveit_config ex_fake_control.launch.py`
- [x] Verify that the cartesian path service works: `ros2 run pymoveit2 ex_pose_goal.py --ros-args -p position:="[0.573, 0.000, 0.488]" -p quat_xyzw:="[1.000, -0.000, 0.001, -0.000]" -p cartesian:=True`