### PR TITLE
Allow clearing all collision objects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ ament_python_install_package(pymoveit2)
 set(EXAMPLES_DIR examples)
 install(PROGRAMS
     ${EXAMPLES_DIR}/ex_allow_collisions.py
+    ${EXAMPLES_DIR}/ex_clear_planning_scene.py
     ${EXAMPLES_DIR}/ex_collision_mesh.py
     ${EXAMPLES_DIR}/ex_collision_primitive.py
     ${EXAMPLES_DIR}/ex_fk.py

--- a/examples/ex_clear_planning_scene.py
+++ b/examples/ex_clear_planning_scene.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Example of clearing the planning scene.
+- ros2 run pymoveit2 ex_clear_planning_scene.py"
+- ros2 run pymoveit2 ex_clear_planning_scene.py --ros-args -p cancel_after:=0.0"
+"""
+
+from os import path
+from threading import Thread
+
+import rclpy
+import trimesh
+from rcl_interfaces.msg import ParameterDescriptor, ParameterType
+from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.node import Node
+
+from pymoveit2 import MoveIt2
+from pymoveit2.robots import panda
+
+
+def main():
+    rclpy.init()
+
+    # Create node for this example
+    node = Node("ex_clear_planning_scene")
+
+    # Declare parameter for joint positions
+    node.declare_parameter(
+        "cancel_after",
+        -1.0,
+        ParameterDescriptor(
+            name="cancel_after",
+            type=ParameterType.PARAMETER_DOUBLE,
+            description=(
+                "The number of seconds after which the service call to clear the "
+                "planning scene should be cancelled. If negative (default), don't cancel."
+            ),
+            read_only=True,
+        ),
+    )
+
+    # Create callback group that allows execution of callbacks in parallel without restrictions
+    callback_group = ReentrantCallbackGroup()
+
+    # Create MoveIt 2 interface
+    moveit2 = MoveIt2(
+        node=node,
+        joint_names=panda.joint_names(),
+        base_link_name=panda.base_link_name(),
+        end_effector_name=panda.end_effector_name(),
+        group_name=panda.MOVE_GROUP_ARM,
+        callback_group=callback_group,
+    )
+
+    # Spin the node in background thread(s) and wait a bit for initialization
+    executor = rclpy.executors.MultiThreadedExecutor(2)
+    executor.add_node(node)
+    executor_thread = Thread(target=executor.spin, daemon=True, args=())
+    executor_thread.start()
+    node.create_rate(1.0).sleep()
+
+    # Get parameters
+    cancel_after = node.get_parameter("cancel_after").get_parameter_value().double_value
+
+    # Clear planning scene
+    future = moveit2.clear_all_collision_objects()
+    start_time = node.get_clock().now()
+    if future is None:
+        node.get_logger().error("Failed to clear planning scene")
+    else:
+        rate = node.create_rate(10)
+        while rclpy.ok() and not future.done():
+            if (
+                cancel_after >= 0.0
+                and (node.get_clock().now() - start_time).nanoseconds / 1e9
+                >= cancel_after
+            ):
+                moveit2.cancel_clear_all_collision_objects_future(future)
+                node.get_logger().info("Cancelled clear planning scene service call")
+                break
+            rate.sleep()
+        if future.cancelled():
+            node.get_logger().info("Cancelled clear planning scene service call")
+        if future.done():
+            success = moveit2.process_clear_all_collision_objects_future(future)
+            if success:
+                node.get_logger().info("Successfully cleared planning scene")
+            else:
+                node.get_logger().error("Failed to clear planning scene")
+
+    rclpy.shutdown()
+    executor_thread.join()
+    exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Description

Although users can theoretically remove all collision obejcts by removing them one-at-a-time with `remove_collision_object`, that process has two downsides: (a) it is slow; and (b) collision object updates that are sent via topic publication are not always processed by MoveIt, particularly if multiple are sent in quick succession.

Thus, this PR adds the ability for users to clear all collision objects in the planning scene via service call.

# Testing

- [x] Launch the [simulated panda arm](https://github.com/AndrejOrsula/panda_ign_moveit2): `ros2 launch panda_moveit_config ex_fake_control.launch.py`
- [x] Add two collision objects, e.g.,:
    - [x] `ros2 run pymoveit2 ex_collision_mesh.py --ros-args -p position:="[0.5, 0.0, 0.0]" -p quat_xyzw:="[0.0, 0.0, -0.7071, 0.7071]"`
    - [x] `ros2 run pymoveit2 ex_collision_primitive.py --ros-args -p shape:="sphere" -p position:="[0.5, 0.0, 0.5]" -p dimensions:="[0.04]"`
- [x] Clear the planning scene, verify it succeeds: `ros2 run pymoveit2 ex_clear_planning_scene.py`
- [x] Re-add the above two collision objects.
- [x] Clear the planning scene and then immediately cancel: `ros2 run pymoveit2 ex_clear_planning_scene.py --ros-args -p cancel_after:=0.0`. Verify that the code succesfully runs. (Note: although the function call will attempt to cancel the service, there is no guarentees that the service will actually be canceled. This is mainly beneficial in case the service is running too long or blocking.)

# Note

I'm okay with either merging it to `master` or `devel`. Since it strictly adds functionality, perhaps it only needs to be a minor release?