### PR TITLE
[Bugfix] Copy mesh before scaling if it was passed in as a parameter

### DIFF
--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -1703,7 +1703,7 @@ class MoveIt2:
         if not (scale[0] == scale[1] == scale[2] == 1.0):
             # If the mesh was passed in as a parameter, make a copy of it to
             # avoid transforming the original.
-            if filepath is not None:
+            if filepath is None:
                 mesh = mesh.copy()
             # Transform the mesh
             transform = np.eye(4)


### PR DESCRIPTION
# Description

#67 allowed users to pass in a preloaded mesh as a parameter, to avoid needing to keep reloading a mesh. That PR correctly realized that if the mesh is passed in as a parameter, we should copy it before scaling, to avoid destructively modifying the mesh that the user passed in. However, that PR had a bug in its implementation of that feature, resulting in it copying the mesh before scaling if the mesh was _not_ passed in as a parameter. This PR addresses that.

# Testing

I tested this PR on my local robot setup, where we pre-load a mesh and then add it multiple times with different scale values. Before the change, the mesh would keep scaling down until near-zero (because the pre-loaded mesh is what gets scaled). After the change, it properly applies the scale (because the pre-loaded mesh remains unmodified).

Let me know if you'd like me to create a test case within this repo / the simulated panda example for this PR. I figured since it is a one-word change, the above should be fine :) 