### PR TITLE
Always specify executor when spinning the node

### DIFF
--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -440,9 +440,6 @@ class MoveIt2:
                     cartesian_fraction_threshold=cartesian_fraction_threshold,
                 )
             )
-            self._node.get_logger().info(
-                f"Executed trajectory with points."
-            )
 
     def move_to_configuration(
         self,

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -529,7 +529,7 @@ class MoveIt2:
 
         if future is None:
             return None
-
+        
         # 100ms sleep
         rate = self._node.create_rate(10)
         while not future.done():

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -533,7 +533,8 @@ class MoveIt2:
         # 100ms sleep
         rate = self._node.create_rate(10)
         while not future.done():
-            rclpy.spin_once(self._node, timeout_sec=1.0)
+            rclpy.spin_once(self._node, executor=self._node.executor,timeout_sec=1.0)
+
 
         return self.get_trajectory(
             future,
@@ -645,7 +646,8 @@ class MoveIt2:
                 start_joint_state = self.__joint_state
                 break
             else:
-                rclpy.spin_once(self._node, timeout_sec=1.0)
+                rclpy.spin_once(self._node, executor=self._node.executor,timeout_sec=1.0)
+
         self._node._logger.info(message="Joint states are available now")
 
         # Plan trajectory asynchronously by service call
@@ -761,7 +763,7 @@ class MoveIt2:
             return False
 
         while self.__is_motion_requested or self.__is_executing:
-            rclpy.spin_once(self._node, timeout_sec=1.0)
+            rclpy.spin_once(self._node, executor=self._node.executor,timeout_sec=1.0)
 
         return self.motion_suceeded
 
@@ -1207,7 +1209,7 @@ class MoveIt2:
         # 100ms sleep
         rate = self._node.create_rate(10)
         while not future.done():
-            rclpy.spin_once(self._node, timeout_sec=1.0)
+            rclpy.spin_once(self._node, executor=self._node.executor,timeout_sec=1.0)
 
         return self.get_compute_fk_result(future, fk_link_names=fk_link_names)
 
@@ -1301,7 +1303,7 @@ class MoveIt2:
         # 10ms sleep
         rate = self._node.create_rate(10)
         while not future.done():
-            rclpy.spin_once(self._node, timeout_sec=1.0)
+            rclpy.spin_once(self._node, executor=self._node.executor,timeout_sec=1.0)
 
         return self.get_compute_ik_result(future)
 

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -440,6 +440,9 @@ class MoveIt2:
                     cartesian_fraction_threshold=cartesian_fraction_threshold,
                 )
             )
+            self._node.get_logger().info(
+                f"Executed trajectory with points."
+            )
 
     def move_to_configuration(
         self,
@@ -717,7 +720,9 @@ class MoveIt2:
         """
         Execute joint_trajectory by communicating directly with the controller.
         """
-
+        self._node.get_logger().info(
+            f"Executing trajectory with {len(joint_trajectory.points)} points."
+        )
         if self.__ignore_new_calls_while_executing and (
             self.__is_motion_requested or self.__is_executing
         ):
@@ -737,6 +742,10 @@ class MoveIt2:
             return
 
         self._send_goal_async_execute_trajectory(goal=execute_trajectory_goal)
+
+        self._node.get_logger().info(
+            f"Trajectory sent for execution"
+        )
 
     def wait_until_executed(self) -> bool:
         """
@@ -2126,12 +2135,18 @@ class MoveIt2:
         wait_until_response: bool = False,
     ):
         self.__execution_mutex.acquire()
-
+        self._node.get_logger().info(
+            f"Sending goal to action server '{self._execute_trajectory_action_client._action_name}'"
+        )
         if not self._execute_trajectory_action_client.server_is_ready():
             self._node.get_logger().warn(
                 f"Action server '{self._execute_trajectory_action_client._action_name}' is not yet available. Better luck next time!"
             )
             return
+
+        self._node.get_logger().info(
+            f"Action server '{self._execute_trajectory_action_client._action_name}' is ready."
+        )
 
         self.__last_error_code = None
         self.__is_motion_requested = True
@@ -2145,9 +2160,18 @@ class MoveIt2:
         self.__send_goal_future_execute_trajectory.add_done_callback(
             self.__response_callback_execute_trajectory
         )
+        self._node.get_logger().info(
+            f"Goal1 sent to action server '{self._execute_trajectory_action_client._action_name}'"
+        )
         self.__execution_mutex.release()
+        self._node.get_logger().info(
+            f"self.__execution_mutex.release()"
+        )
 
     def __response_callback_execute_trajectory(self, response):
+        self._node.get_logger().info(
+            f"Response received from action server '{self._execute_trajectory_action_client._action_name}'"
+        )
         self.__execution_mutex.acquire()
         goal_handle = response.result()
         if not goal_handle.accepted:

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -720,9 +720,11 @@ class MoveIt2:
         """
         Execute joint_trajectory by communicating directly with the controller.
         """
-        self._node.get_logger().info(
-            f"Executing trajectory with {len(joint_trajectory.points)} points."
-        )
+        if joint_trajectory is not None and len(joint_trajectory.points) > 0 :
+            self._node.get_logger().info(
+                f"Executing trajectory with {len(joint_trajectory.points)} points."
+            )
+
         if self.__ignore_new_calls_while_executing and (
             self.__is_motion_requested or self.__is_executing
         ):

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -722,10 +722,6 @@ class MoveIt2:
         """
         Execute joint_trajectory by communicating directly with the controller.
         """
-        if joint_trajectory is not None and len(joint_trajectory.points) > 0 :
-            self._node.get_logger().info(
-                f"Executing trajectory with {len(joint_trajectory.points)} points."
-            )
 
         if self.__ignore_new_calls_while_executing and (
             self.__is_motion_requested or self.__is_executing
@@ -746,10 +742,6 @@ class MoveIt2:
             return
 
         self._send_goal_async_execute_trajectory(goal=execute_trajectory_goal)
-
-        self._node.get_logger().info(
-            f"Trajectory sent for execution"
-        )
 
     def wait_until_executed(self) -> bool:
         """
@@ -2139,18 +2131,12 @@ class MoveIt2:
         wait_until_response: bool = False,
     ):
         self.__execution_mutex.acquire()
-        self._node.get_logger().info(
-            f"Sending goal to action server '{self._execute_trajectory_action_client._action_name}'"
-        )
+        
         if not self._execute_trajectory_action_client.server_is_ready():
             self._node.get_logger().warn(
                 f"Action server '{self._execute_trajectory_action_client._action_name}' is not yet available. Better luck next time!"
             )
             return
-
-        self._node.get_logger().info(
-            f"Action server '{self._execute_trajectory_action_client._action_name}' is ready."
-        )
 
         self.__last_error_code = None
         self.__is_motion_requested = True
@@ -2164,18 +2150,9 @@ class MoveIt2:
         self.__send_goal_future_execute_trajectory.add_done_callback(
             self.__response_callback_execute_trajectory
         )
-        self._node.get_logger().info(
-            f"Goal1 sent to action server '{self._execute_trajectory_action_client._action_name}'"
-        )
         self.__execution_mutex.release()
-        self._node.get_logger().info(
-            f"self.__execution_mutex.release()"
-        )
 
     def __response_callback_execute_trajectory(self, response):
-        self._node.get_logger().info(
-            f"Response received from action server '{self._execute_trajectory_action_client._action_name}'"
-        )
         self.__execution_mutex.acquire()
         goal_handle = response.result()
         if not goal_handle.accepted:

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -526,12 +526,11 @@ class MoveIt2:
 
         if future is None:
             return None
-        
+
         # 100ms sleep
         rate = self._node.create_rate(10)
         while not future.done():
-            rclpy.spin_once(self._node, executor=self._node.executor,timeout_sec=1.0)
-
+            rclpy.spin_once(self._node, executor=self._node.executor, timeout_sec=1.0)
 
         return self.get_trajectory(
             future,
@@ -643,7 +642,9 @@ class MoveIt2:
                 start_joint_state = self.__joint_state
                 break
             else:
-                rclpy.spin_once(self._node, executor=self._node.executor,timeout_sec=1.0)
+                rclpy.spin_once(
+                    self._node, executor=self._node.executor, timeout_sec=1.0
+                )
 
         self._node._logger.info(message="Joint states are available now")
 
@@ -752,7 +753,7 @@ class MoveIt2:
             return False
 
         while self.__is_motion_requested or self.__is_executing:
-            rclpy.spin_once(self._node, executor=self._node.executor,timeout_sec=1.0)
+            rclpy.spin_once(self._node, executor=self._node.executor, timeout_sec=1.0)
 
         return self.motion_suceeded
 
@@ -1198,7 +1199,7 @@ class MoveIt2:
         # 100ms sleep
         rate = self._node.create_rate(10)
         while not future.done():
-            rclpy.spin_once(self._node, executor=self._node.executor,timeout_sec=1.0)
+            rclpy.spin_once(self._node, executor=self._node.executor, timeout_sec=1.0)
 
         return self.get_compute_fk_result(future, fk_link_names=fk_link_names)
 
@@ -1292,7 +1293,7 @@ class MoveIt2:
         # 10ms sleep
         rate = self._node.create_rate(10)
         while not future.done():
-            rclpy.spin_once(self._node, executor=self._node.executor,timeout_sec=1.0)
+            rclpy.spin_once(self._node, executor=self._node.executor, timeout_sec=1.0)
 
         return self.get_compute_ik_result(future)
 
@@ -2128,7 +2129,7 @@ class MoveIt2:
         wait_until_response: bool = False,
     ):
         self.__execution_mutex.acquire()
-        
+
         if not self._execute_trajectory_action_client.server_is_ready():
             self._node.get_logger().warn(
                 f"Action server '{self._execute_trajectory_action_client._action_name}' is not yet available. Better luck next time!"


### PR DESCRIPTION
This PR fixes a potential issue introduced in [1f030f6](https://github.com/AndrejOrsula/pymoveit2/commit/1f030f6072dac16914c91d1368926f182ea5f1fc), where rclpy.spin_once() was called without passing the node's executor.

Calling spin_once(node) without an explicit executor causes the node to be added to a global executor temporarily and then removed. If the node was already attached to a custom MultiThreadedExecutor, this breaks subsequent usage and can result in runtime exceptions in rclpy's event_handler.py, like:
`IndexError: wait set index too big`

The fix is to call:
`rclpy.spin_once(node, executor=node.executor, timeout_sec=...)`
so that the node stays associated with the correct executor.
This is inline with a recent change in `spin_once()' that was introduced [recently](https://github.com/ros2/rclpy/pull/1446).

Fixes #93 