### PR TITLE
Revert #94, add trimesh to ROS dependencies, and remove sync param from `reset_controller()` methods

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <exec_depend>shape_msgs</exec_depend>
   <exec_depend>std_srvs</exec_depend>
   <exec_depend>trajectory_msgs</exec_depend>
+  <exec_depend>python3-trimesh-pip</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -152,11 +152,7 @@ class MoveIt2:
         self.motion_suceeded = False
         self.__execution_goal_handle = None
         self.__last_error_code = None
-        self.__wait_until_executed_rate = self._node.create_rate(1000.0)
         self.__execution_mutex = threading.Lock()
-
-        # Event that enables waiting until async future is done
-        self.__future_done_event = threading.Event()
 
         # Create subscriber for current joint states
         self._node.create_subscription(
@@ -527,8 +523,6 @@ class MoveIt2:
         if future is None:
             return None
 
-        # 100ms sleep
-        rate = self._node.create_rate(10)
         while not future.done():
             rclpy.spin_once(self._node, timeout_sec=1.0)
 
@@ -755,7 +749,8 @@ class MoveIt2:
         return self.motion_suceeded
 
     def reset_controller(
-        self, joint_state: Union[JointState, List[float]], sync: bool = True
+        self,
+        joint_state: Union[JointState, List[float]],
     ):
         """
         Reset controller to a given `joint_state` by sending a dummy joint trajectory.
@@ -772,10 +767,7 @@ class MoveIt2:
             joint_trajectory=joint_trajectory
         )
 
-        self._send_goal_async_execute_trajectory(
-            goal=execute_trajectory_goal,
-            wait_until_response=sync,
-        )
+        self._send_goal_async_execute_trajectory(goal=execute_trajectory_goal)
 
     def set_pose_goal(
         self,
@@ -1193,8 +1185,6 @@ class MoveIt2:
         if future is None:
             return None
 
-        # 100ms sleep
-        rate = self._node.create_rate(10)
         while not future.done():
             rclpy.spin_once(self._node, timeout_sec=1.0)
 
@@ -1287,8 +1277,6 @@ class MoveIt2:
         if future is None:
             return None
 
-        # 10ms sleep
-        rate = self._node.create_rate(10)
         while not future.done():
             rclpy.spin_once(self._node, timeout_sec=1.0)
 
@@ -2123,7 +2111,6 @@ class MoveIt2:
     def _send_goal_async_execute_trajectory(
         self,
         goal: ExecuteTrajectory,
-        wait_until_response: bool = False,
     ):
         self.__execution_mutex.acquire()
 
@@ -2166,9 +2153,6 @@ class MoveIt2:
             self.__result_callback_execute_trajectory
         )
         self.__execution_mutex.release()
-
-    def __response_callback_with_event_set_execute_trajectory(self, response):
-        self.__future_done_event.set()
 
     def __result_callback_execute_trajectory(self, res):
         self.__execution_mutex.acquire()

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -530,7 +530,7 @@ class MoveIt2:
         # 100ms sleep
         rate = self._node.create_rate(10)
         while not future.done():
-            rclpy.spin_once(self._node, executor=self._node.executor, timeout_sec=1.0)
+            rclpy.spin_once(self._node, timeout_sec=1.0)
 
         return self.get_trajectory(
             future,
@@ -642,10 +642,7 @@ class MoveIt2:
                 start_joint_state = self.__joint_state
                 break
             else:
-                rclpy.spin_once(
-                    self._node, executor=self._node.executor, timeout_sec=1.0
-                )
-
+                rclpy.spin_once(self._node, timeout_sec=1.0)
         self._node._logger.info(message="Joint states are available now")
 
         # Plan trajectory asynchronously by service call
@@ -753,7 +750,7 @@ class MoveIt2:
             return False
 
         while self.__is_motion_requested or self.__is_executing:
-            rclpy.spin_once(self._node, executor=self._node.executor, timeout_sec=1.0)
+            rclpy.spin_once(self._node, timeout_sec=1.0)
 
         return self.motion_suceeded
 
@@ -1199,7 +1196,7 @@ class MoveIt2:
         # 100ms sleep
         rate = self._node.create_rate(10)
         while not future.done():
-            rclpy.spin_once(self._node, executor=self._node.executor, timeout_sec=1.0)
+            rclpy.spin_once(self._node, timeout_sec=1.0)
 
         return self.get_compute_fk_result(future, fk_link_names=fk_link_names)
 
@@ -1293,7 +1290,7 @@ class MoveIt2:
         # 10ms sleep
         rate = self._node.create_rate(10)
         while not future.done():
-            rclpy.spin_once(self._node, executor=self._node.executor, timeout_sec=1.0)
+            rclpy.spin_once(self._node, timeout_sec=1.0)
 
         return self.get_compute_ik_result(future)
 

--- a/pymoveit2/moveit2_gripper.py
+++ b/pymoveit2/moveit2_gripper.py
@@ -178,25 +178,21 @@ class MoveIt2Gripper(MoveIt2):
         joint_positions = [position for _ in self.joint_names]
         self.move_to_configuration(joint_positions=joint_positions)
 
-    def reset_open(self, sync: bool = True):
+    def reset_open(self):
         """
         Reset into open configuration by sending a dummy joint trajectory.
         This is useful for simulated robots that allow instantaneous reset of joints.
         """
 
-        self.reset_controller(
-            joint_state=self.__open_gripper_joint_positions, sync=sync
-        )
+        self.reset_controller(joint_state=self.__open_gripper_joint_positions)
 
-    def reset_closed(self, sync: bool = True):
+    def reset_closed(self):
         """
         Reset into closed configuration by sending a dummy joint trajectory.
         This is useful for simulated robots that allow instantaneous reset of joints.
         """
 
-        self.reset_controller(
-            joint_state=self.__closed_gripper_joint_positions, sync=sync
-        )
+        self.reset_controller(joint_state=self.__closed_gripper_joint_positions)
 
     def __open_without_planning(self):
         self._send_goal_async_follow_joint_trajectory(


### PR DESCRIPTION
Just cleaning up some unused variables and parameters. This breaks API.

This also reverts https://github.com/AndrejOrsula/pymoveit2/pull/94 due to https://github.com/AndrejOrsula/pymoveit2/issues/95.