### PR TITLE
CI: Add build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,3 +29,20 @@ jobs:
           ROS_DISTRO: ${{ matrix.ros }}
           DEB_DISTRO: ${{ matrix.deb }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Runner Codename
+        run: |
+          echo "CODENAME=$(lsb_release -cs)" >> $GITHUB_ENV
+
+      - name: Remove Conflicting Debian Packages
+        if: ${{ matrix.deb == env.CODENAME }}
+        run: |
+          sudo apt -y autoremove --purge python3-catkin-pkg python3-rospkg python3-rosdistro vcstool
+
+      - uses: ros-tooling/setup-ros@v0.7
+        if: ${{ matrix.deb == env.CODENAME }}
+
+      - name: Install pymoveit2 Debian Packages
+        if: ${{ matrix.deb == env.CODENAME }}
+        run: |
+          sudo apt -y install ./apt_repo/ros-*-pymoveit2_*.deb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           ROS_DISTRO: ${{ matrix.ros }}
           DEB_DISTRO: ${{ matrix.deb }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Runner Codename
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,14 +18,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ros_distro:
-          - humble
-          - jazzy
-          - rolling
+        include:
+          - {deb: jammy, ros: humble}
+          - {deb: noble, ros: jazzy}
+          - {deb: noble, ros: rolling}
     steps:
       - name: Build for ROS ${{ matrix.ros_distro }}
         uses: jspricke/ros-deb-builder-action@main
         with:
-          DEB_DISTRO: ${{ (matrix.ros_distro == 'humble' && 'jammy') || 'noble' }}
-          ROS_DISTRO: ${{ matrix.ros_distro }}
+          ROS_DISTRO: ${{ matrix.ros }}
+          DEB_DISTRO: ${{ matrix.deb }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: build
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  build_testing:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ros_distro:
+          - humble
+          - jazzy
+          - rolling
+    steps:
+      - name: Build for ROS ${{ matrix.ros_distro }}
+        uses: jspricke/ros-deb-builder-action@main
+        with:
+          DEB_DISTRO: ${{ (matrix.ros_distro == 'humble' && 'jammy') || 'noble' }}
+          ROS_DISTRO: ${{ matrix.ros_distro }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           ROS_DISTRO: ${{ matrix.ros }}
           DEB_DISTRO: ${{ matrix.deb }}
-          # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Runner Codename
         run: |


### PR DESCRIPTION
Add [ros-deb-builder-action](https://github.com/jspricke/ros-deb-builder-action) CI workflow, as suggested by @christian-rauch in https://github.com/AndrejOrsula/pymoveit2/issues/92#issuecomment-2851477275.