### PR TITLE
comment out trimesh pip dependency for bloom package

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,7 +19,7 @@
   <exec_depend>shape_msgs</exec_depend>
   <exec_depend>std_srvs</exec_depend>
   <exec_depend>trajectory_msgs</exec_depend>
-  <exec_depend>python3-trimesh-pip</exec_depend>
+  <!-- <exec_depend>python3-trimesh-pip</exec_depend> -->
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
As discussed in https://github.com/AndrejOrsula/pymoveit2/pull/97#issuecomment-2870213121, the `python3-trimesh-pip` rosdep key is resolved to a pip package, which cannot be used for bloom releases. A [`python3-trimesh`](https://packages.ubuntu.com/plucky/python3-trimesh) Debian package is available for Ubuntu 25.04 onwards and could be used for the next ROS LTS release.