### PR TITLE
Apply the custom start joint state to the request

### DIFF
--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -642,12 +642,16 @@ class MoveIt2:
         # Ensure the request actually uses the intended start state
         if start_joint_state is not None:
             if isinstance(start_joint_state, JointState):
-                self.__move_action_goal.request.start_state.joint_state = start_joint_state
+                self.__move_action_goal.request.start_state.joint_state = (
+                    start_joint_state
+                )
             else:
                 # start_joint_state is a list of positions
-                self.__move_action_goal.request.start_state.joint_state = init_joint_state(
-                    joint_names=self.__joint_names,
-                    joint_positions=start_joint_state,
+                self.__move_action_goal.request.start_state.joint_state = (
+                    init_joint_state(
+                        joint_names=self.__joint_names,
+                        joint_positions=start_joint_state,
+                    )
                 )
         elif self.joint_state is not None:
             # Default to the latest observed state if none provided

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -639,6 +639,20 @@ class MoveIt2:
                 rclpy.spin_once(self._node, timeout_sec=1.0)
         self._node._logger.info(message="Joint states are available now")
 
+        # Ensure the request actually uses the intended start state
+        if start_joint_state is not None:
+            if isinstance(start_joint_state, JointState):
+                self.__move_action_goal.request.start_state.joint_state = start_joint_state
+            else:
+                # start_joint_state is a list of positions
+                self.__move_action_goal.request.start_state.joint_state = init_joint_state(
+                    joint_names=self.__joint_names,
+                    joint_positions=start_joint_state,
+                )
+        elif self.joint_state is not None:
+            # Default to the latest observed state if none provided
+            self.__move_action_goal.request.start_state.joint_state = self.joint_state
+
         # Plan trajectory asynchronously by service call
         if cartesian:
             future = self._plan_cartesian_path(


### PR DESCRIPTION
Currently, even when a `custom_start_state` is passed, the `MotionPlanRequest.start_state` is left unset, causing MoveIt to see an empty start state and fall back to the planning scene’s current state.

This patch ensures that `plan_async` explicitly assigns the provided `start_joint_state` (or defaults to the latest observed joint state), so requests now include the intended start state and avoid adaptor warnings.

Testing this resulted in our plans working as expected when providing a custom start state.